### PR TITLE
docs: update GitHub Actions versions in documentation examples

### DIFF
--- a/.github/actions/validate-coverage/README.md
+++ b/.github/actions/validate-coverage/README.md
@@ -141,7 +141,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Run Tests
         run: dotnet test --collect:"XPlat Code Coverage"
@@ -166,7 +166,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Run Tests
         run: dotnet test --collect:"XPlat Code Coverage"
@@ -191,7 +191,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Run Tests
         run: dotnet test --collect:"XPlat Code Coverage"

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -429,10 +429,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
       
@@ -456,7 +456,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Run CodeQL Analysis
         uses: github/codeql-action/init@v2
@@ -480,7 +480,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Login to Container Registry
         uses: docker/login-action@v2
@@ -516,7 +516,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Azure Login
         uses: azure/login@v1
@@ -540,7 +540,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Azure Login
         uses: azure/login@v1
@@ -570,10 +570,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.x'
       

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -657,10 +657,10 @@ Para receber notificações quando novas versões estáveis forem lançadas, con
        check-outdated:
          runs-on: ubuntu-latest
          steps:
-           - uses: actions/checkout@v4
+           - uses: actions/checkout@v6
            
            - name: Setup .NET
-             uses: actions/setup-dotnet@v4
+             uses: actions/setup-dotnet@v5
              with:
                dotnet-version: '10.x'
            


### PR DESCRIPTION
Updates workflow examples in documentation to reflect actual versions after Dependabot PRs #22-24.

## Changes

### actions/checkout: v4 → v6
- .github/actions/validate-coverage/README.md (3 examples)
- docs/ci-cd.md (6 examples)
- docs/roadmap.md (1 example)

### actions/setup-dotnet: v3/v4 → v5
- docs/ci-cd.md (2 examples)
- docs/roadmap.md (1 example)

## Context

After merging Dependabot PRs that updated GitHub Actions to their latest versions, the documentation examples were still showing old versions. This PR synchronizes the documentation with the actual workflow files.

## Related PRs
- #22 - ci(deps): bump actions/setup-dotnet from 4 to 5
- #23 - ci(deps): bump actions/checkout from 4 to 6
- #24 - ci(deps): bump actions/upload-artifact from 4 to 5

## Checklist
- [x] Documentation examples updated
- [x] No functional changes
- [x] All examples tested for syntax correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies: checkout action upgraded from v4 to v6 and .NET setup action upgraded to v5 across CI/CD workflows to improve compatibility and compatibility with newer runner features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->