### PR TITLE
Align Keycloak Realms and Roadmap Transition to Sprint 11

### DIFF
--- a/docs/roadmap-history.md
+++ b/docs/roadmap-history.md
@@ -4,6 +4,20 @@ Este documento contém o registro de todas as sprints concluídas para fins de a
 
 ---
 
+## ✅ Sprint 10 - Qualidade & Onboarding (Concluída em 14 Abr 2026)
+
+**Objetivo**: Estabelecer confiança na plataforma através de avaliações e simplificar o acesso de novos prestadores.
+
+### Entregas:
+- ✅ **Ratings Module**: Sistema de avaliações completo com desnormalização para performance de busca.
+- ✅ **Moderação**: Filtros automáticos e manuais para comentários.
+- ✅ **Login Social (Instagram)**: Reintegração via OIDC sincronizada entre ambientes (Issue #141).
+- ✅ **Infra CI/CD**: OpenAPI Breaking Change Gating funcional no pipeline.
+- ✅ **Documentação**: 100% de cobertura de coleções Bruno (.bru) para módulos ativos.
+- ✅ **Keycloak Alignment**: Realms de `dev` e `prod` estruturalmente sincronizados (Roles e Clients).
+
+---
+
 ## ✅ Sprint 9 - BUFFER & Mitigação de Risco (Concluída em 11 Abr 2026)
 
 **Foco**: Estabilização, Refatoração e Módulo de Comunicações (Infra).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -52,7 +52,7 @@ Este é o planejamento estratégico unificado da plataforma MeAjudaAi.
 
 ## ✅ Concluído Recentemente
 
-*   **Sprint 10**: Módulo de Ratings, Moderação de Conteúdo, Login Social Instagram (#141) e Alinhamento de Realms Keycloak.
+*   **Sprint 10**: Módulo de Ratings, Moderação de Conteúdo, Login Social Instagram (#141), Alinhamento de Realms Keycloak, Infra CI/CD (OpenAPI gating) e Documentação (coleções Bruno).
 *   **Sprint 9**: Estabilização global, Módulo de Comunicações (Infra), Resiliência (`CancellationToken`) e Localização Backend (.resx).
 *   **Sprint 8D/8E**: Migração completa do Admin Portal para React e Testes E2E com Playwright.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ Este é o planejamento estratégico unificado da plataforma MeAjudaAi.
 
 ## 📊 Status Atual (Abril 2026)
 
-**Sprint Atual**: 10 (Qualidade & Onboarding)
+**Sprint Atual**: 11 (Monetização & Polimento)
 **Status**: 🚧 Em andamento
 **Meta MVP**: 12 - 16 de Maio de 2026
 
@@ -14,32 +14,7 @@ Este é o planejamento estratégico unificado da plataforma MeAjudaAi.
 
 ---
 
-## 🚀 Sprint 10 - Qualidade & Onboarding (12 Abr - 26 Abr 2026) 🚧 [EM ANDAMENTO]
-
-**Objetivo**: Estabelecer confiança na plataforma através de avaliações e simplificar o acesso de novos prestadores.
-
-### 🔴 MUST-HAVE:
-
-#### 1. 🌟 Ratings Module (Módulo de Avaliações) ✅ [CONCLUÍDO]
-*   **Arquitetura**: **Consistência Eventual**. O módulo de busca (`SearchProviders`) não fará Join com o módulo de Ratings. Sempre que um review for aprovado, um `ReviewApprovedIntegrationEvent` será disparado e o módulo de busca atualizará o campo `AverageRating` no seu próprio registro desnormalizado.
-*   **Funcionalidades**:
-    *   ✅ **Avaliação de Prestadores**: Clientes podem adicionar nota (1 a 5 estrelas) e comentário textual após a conclusão de um serviço.
-    *   ✅ **Moderação de Conteúdo**: Filtro automático via Regex e manual para comentários que violem as regras (xingamentos, ofensas, SPAM).
-    *   ✅ **Ranking de Busca**: Algoritmo de busca priorizando prestadores com melhor média e maior volume de avaliações verificadas.
-*   **Schema DB**: `ratings` | **ModuleName**: `Ratings`.
-
-#### 2. 🔑 Login Social (Instagram) - ISSUE #141 ✅ [CONCLUÍDO]
-*   **Ação**: Configuração de Identity Provider nativo do Instagram no Keycloak para permitir que prestadores usem seu perfil do Instagram para autenticação.
-
-#### 3. 🛡️ OpenAPI Breaking Change Gating (CI) ✅ [CONCLUÍDO]
-*   **Ação**: Novo step no workflow de PR para comparar o `api-base.json` com `api-current/api-spec.json` usando `breaking-only` e `fail-on-diff` para falhar o build caso existam mudanças destrutivas na API. Corrigido para rodar em ambiente `Testing` para evitar dependências de segredos reais.
-
-#### 4. 📋 Coleções Bruno (.bru) ✅ [CONCLUÍDO]
-*   **Ação**: Documentação técnica de 100% dos endpoints existentes em `src/Modules/*/API/API.Client/`.
-
----
-
-## 💰 Sprint 11 - Monetização & Polimento (27 Abr - 11 Mai 2026) [EM PLANEJAMENTO]
+## 💰 Sprint 11 - Monetização & Polimento (27 Abr - 11 Mai 2026) 🚧 [EM ANDAMENTO]
 
 **Objetivo**: Habilitar o faturamento da plataforma e finalizar a experiência do usuário.
 
@@ -77,6 +52,7 @@ Este é o planejamento estratégico unificado da plataforma MeAjudaAi.
 
 ## ✅ Concluído Recentemente
 
+*   **Sprint 10**: Módulo de Ratings, Moderação de Conteúdo, Login Social Instagram (@issue #141) e Alinhamento de Realms Keycloak.
 *   **Sprint 9**: Estabilização global, Módulo de Comunicações (Infra), Resiliência (`CancellationToken`) e Localização Backend (.resx).
 *   **Sprint 8D/8E**: Migração completa do Admin Portal para React e Testes E2E com Playwright.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@ Este é o planejamento estratégico unificado da plataforma MeAjudaAi.
 
 ---
 
-## 💰 Sprint 11 - Monetização & Polimento (27 Abr - 11 Mai 2026) 🚧 [EM ANDAMENTO]
+## 💰 Sprint 11 - Monetização & Polimento (13 Abr - 27 Abr 2026) 🚧 [EM ANDAMENTO]
 
 **Objetivo**: Habilitar o faturamento da plataforma e finalizar a experiência do usuário.
 
@@ -52,7 +52,7 @@ Este é o planejamento estratégico unificado da plataforma MeAjudaAi.
 
 ## ✅ Concluído Recentemente
 
-*   **Sprint 10**: Módulo de Ratings, Moderação de Conteúdo, Login Social Instagram (@issue #141) e Alinhamento de Realms Keycloak.
+*   **Sprint 10**: Módulo de Ratings, Moderação de Conteúdo, Login Social Instagram (#141) e Alinhamento de Realms Keycloak.
 *   **Sprint 9**: Estabilização global, Módulo de Comunicações (Infra), Resiliência (`CancellationToken`) e Localização Backend (.resx).
 *   **Sprint 8D/8E**: Migração completa do Admin Portal para React e Testes E2E com Playwright.
 

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -9,44 +9,17 @@ Este documento rastreia **débitos técnicos e seu histórico de otimização**.
 **Sprint**: Sprint 6-7 (30 Dez 2025 - 16 Jan 2026)  
 **Status**: Itens de baixa a média prioridade
 
-### 📊 Frontend - Cobertura de Testes (MÉDIA)
-
-**Severidade**: MÉDIA (quality assurance)  
-**Status**: 🔄 EM SPRINT 8E (E2E Tests com Playwright)
-
-**Descrição**: Admin Portal foi migrado para React. Testes de frontend agora focam em E2E com Playwright.
-
-**Framework de Testes**: Playwright (para todos os apps React)
-- Customer Web App
-- Provider Web App
-- Admin Portal (React)
-
-**BDD**: Playwright para testes end-to-end de fluxos completos (Frontend → Backend → APIs terceiras).
-
----
 
 
 ## 🔄 Refatorações de Código (BACKLOG)
 
 **Status**: Baixa prioridade, não críticos para MVP
 
-### 🏗️ Refatoração MeAjudaAi.Shared.Messaging (OTIMIZADO)
-
-**Status**: ✅ `IRabbitMqInfrastructureManager` implementado.
-**Pendente**: Event handlers para comunicação entre novos módulos (SearchProviders, ServiceCatalogs).
-
----
 
 ## 🔗 GitHub Issues - Débitos Técnicos Sincronizados
 
 
 
-### 🚀 [ISSUE #112] tech: aguardar versão stable do Aspire.Hosting.Keycloak
-**Status**: 📋 OTIMIZADO (Sprint 8B.2)  
-**Descrição**: Aspire.Hosting.Keycloak (preview) não suporta health checks reais. Serviços iniciam sem esperar Keycloak estar pronto.
-**Impacto**: Console logs do backend e Admin Portal mostram falhas de conexão transientes até Keycloak inicializar.
-
----
 
 ## ⚠️ CRÍTICO: Hangfire + Npgsql 10.x Compatibility Risk
 
@@ -92,9 +65,7 @@ Este documento rastreia **débitos técnicos e seu histórico de otimização**.
 **Severidade**: MÉDIA  
 **Sprint**: Backlog
 
-- [ ] Apply CancellationToken to ServiceCatalogs/Documents/Locations Effects
-- [ ] Add per-component CancellationTokenSource
-- [ ] Implement navigation-triggered cancellation
+- [ ] Implement focus-based cancellation strategy
 
 **Origem**: Sprint 7.18
 
@@ -113,13 +84,6 @@ Este documento rastreia **débitos técnicos e seu histórico de otimização**.
 
 ---
 
-## ✅ Resumo de Débitos Técnicos Resolvidos (Sprint 8B.2 - Tech Excellence)
-
-### 🛡️ Final Technical Excellence - Automação e Padrões
-- ✅ **Automação Keycloak**: Implementado `KeycloakBootstrapService` no AppHost para criar automaticamente os clients via API REST do Keycloak durante a inicialização, substituindo a necessidade de scripts PowerShell externos.
-- ✅ **Refatoração Shared**: Extensões de monitoramento centralizadas em `MonitoringExtensions.cs`.
-- ✅ **Issue #113**: Configuração de logging de resiliência HTTP com Polly modernizada para injetar `ILogger` a partir do DI, corrigindo problemas de log tracking.
-- ✅ **Padronização de Records**: Sintaxe de DTOs atualizada para o formato "Positional Records" (ex: `ModuleDocumentDto`), mantendo a abordagem property-based apenas onde há validação complexa de domínio.
 ## 📝 Instruções para Mantenedores
 
 1. **Conversão para Issues**: Copiar descrição para GitHub issue com labels (`technical-debt`, `testing`, `enhancement`)

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -39,10 +39,6 @@ Este documento rastreia **débitos técnicos e seu histórico de otimização**.
 
 ## 🔗 GitHub Issues - Débitos Técnicos Sincronizados
 
-### 🔐 [ISSUE #141] Reintegrar login social com Instagram via Keycloak OIDC
-**Severidade**: BAIXA (feature parity)
-**Status**: ✅ OTIMIZADO (Sprint 10)
-**Resolução**: Configurado como generic OIDC e sincronizado entre os realms `dev` e `prod`.
 
 
 ### 🚀 [ISSUE #112] tech: aguardar versão stable do Aspire.Hosting.Keycloak

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -41,8 +41,8 @@ Este documento rastreia **débitos técnicos e seu histórico de otimização**.
 
 ### 🔐 [ISSUE #141] Reintegrar login social com Instagram via Keycloak OIDC
 **Severidade**: BAIXA (feature parity)
-**Status**: OPEN
-**Descrição**: Keycloak 26.x removeu built-in Instagram provider. Necessário configurar como generic OIDC.
+**Status**: ✅ OTIMIZADO (Sprint 10)
+**Resolução**: Configurado como generic OIDC e sincronizado entre os realms `dev` e `prod`.
 
 
 ### 🚀 [ISSUE #112] tech: aguardar versão stable do Aspire.Hosting.Keycloak

--- a/infrastructure/keycloak/realms/meajudaai-realm.dev.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.dev.json
@@ -129,20 +129,23 @@
                                              }
                               },
                               {
-                                  "trustEmail":  false,
-                                  "providerId":  "oidc",
-                                  "_comment": "Nota: O suporte nativo ao provedor Instagram foi removido no Keycloak 26.x. Utilizando OIDC genérico como alternativa conforme Issue #141.",
+                                  "alias":  "instagram",
+                                  "displayName":  "Instagram",
+                                  "providerId":  "facebook",
+                                  "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API.",
                                   "enabled":  true,
-                                  "authenticateByDefault":  false,
+                                  "trustEmail":  false,
                                   "storeToken":  false,
+                                  "addReadTokenRoleOnCreate":  false,
+                                  "authenticateByDefault":  false,
+                                  "firstBrokerLoginFlowAlias":  "first broker login",
                                   "config":  {
                                                  "clientId":  "${INSTAGRAM_CLIENT_ID}",
-                                                 "clientSecret":  "${INSTAGRAM_CLIENT_SECRET}"
-                                             },
-                                  "alias":  "instagram",
-                                  "addReadTokenRoleOnCreate":  false,
-                                  "firstBrokerLoginFlowAlias":  "first broker login",
-                                  "displayName":  "Instagram"
+                                                 "clientSecret":  "${INSTAGRAM_CLIENT_SECRET}",
+                                                 "authorizationUrl": "https://api.instagram.com/oauth/authorize",
+                                                 "tokenUrl": "https://api.instagram.com/oauth/access_token",
+                                                 "userInfoUrl": "https://graph.instagram.com/me?fields=id,username"
+                                             }
                               }
                           ],
     "clients":  [
@@ -199,7 +202,7 @@
                         "publicClient":  true,
                         "standardFlowEnabled":  true,
                         "implicitFlowEnabled":  false,
-                        "directAccessGrantsEnabled":  true,
+                        "directAccessGrantsEnabled":  false,
                         "serviceAccountsEnabled":  false,
                         "protocol":  "openid-connect",
                         "redirectUris":  [
@@ -243,7 +246,7 @@
                         "publicClient":  true,
                         "standardFlowEnabled":  true,
                         "implicitFlowEnabled":  false,
-                        "directAccessGrantsEnabled":  true,
+                        "directAccessGrantsEnabled":  false,
                         "serviceAccountsEnabled":  false,
                         "protocol":  "openid-connect",
                         "redirectUris":  [
@@ -304,8 +307,7 @@
                       "serviceAccountClientId":  "meajudaai-api-service",
                       "clientRoles":  {
                                           "realm-management":  [
-                                                                   "view-users",
-                                                                   "query-users",
+                                                                   "manage-users",
                                                                    "view-realm"
                                                                ]
                                       }

--- a/infrastructure/keycloak/realms/meajudaai-realm.dev.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.dev.json
@@ -132,7 +132,7 @@
                                   "alias":  "instagram",
                                   "displayName":  "Instagram",
                                   "providerId":  "facebook",
-                                  "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API.",
+                                  "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API (OAuth2 puro, sem OIDC).",
                                   "enabled":  true,
                                   "trustEmail":  false,
                                   "storeToken":  false,

--- a/infrastructure/keycloak/realms/meajudaai-realm.dev.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.dev.json
@@ -130,7 +130,8 @@
                               },
                               {
                                   "trustEmail":  false,
-                                  "providerId":  "instagram",
+                                  "providerId":  "oidc",
+                                  "_comment": "Nota: O suporte nativo ao provedor Instagram foi removido no Keycloak 26.x. Utilizando OIDC genérico como alternativa conforme Issue #141.",
                                   "enabled":  true,
                                   "authenticateByDefault":  false,
                                   "storeToken":  false,

--- a/infrastructure/keycloak/realms/meajudaai-realm.dev.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.dev.json
@@ -92,6 +92,22 @@
                                     "description":  "Gerente de localidades - gerenciar cidades e estados"
                                 },
                                 {
+                                    "name":  "meajudaai-provider-standard",
+                                    "description":  "Prestador de serviços - Plano Standard (Gratuito)"
+                                },
+                                {
+                                    "name":  "meajudaai-provider-silver",
+                                    "description":  "Prestador de serviços - Plano Silver (Premium)"
+                                },
+                                {
+                                    "name":  "meajudaai-provider-gold",
+                                    "description":  "Prestador de serviços - Plano Gold (Premium Plus)"
+                                },
+                                {
+                                    "name":  "meajudaai-provider-platinum",
+                                    "description":  "Prestador de serviços - Plano Platinum (Elite)"
+                                },
+                                {
                                     "name":  "customer",
                                     "description":  "Cliente da plataforma"
                                 }
@@ -131,8 +147,8 @@
                               {
                                   "alias":  "instagram",
                                   "displayName":  "Instagram",
-                                  "providerId":  "facebook",
-                                  "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API (OAuth2 puro, sem OIDC).",
+                                  "providerId":  "oauth2",
+                                  "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor OAuth2 genérico para garantir que as URLs da Basic Display API sejam respeitadas e contornar a ausência de OIDC discovery no Instagram.",
                                   "enabled":  true,
                                   "trustEmail":  false,
                                   "storeToken":  false,
@@ -144,10 +160,44 @@
                                                  "clientSecret":  "${INSTAGRAM_CLIENT_SECRET}",
                                                  "authorizationUrl": "https://api.instagram.com/oauth/authorize",
                                                  "tokenUrl": "https://api.instagram.com/oauth/access_token",
-                                                 "userInfoUrl": "https://graph.instagram.com/me?fields=id,username"
+                                                 "userInfoUrl": "https://graph.instagram.com/me?fields=id,username",
+                                                 "defaultScope": "user_profile",
+                                                 "syncMode": "IMPORT",
+                                                 "userIp": "false"
                                              }
                               }
                           ],
+    "identityProviderMappers": [
+        {
+            "identityProviderAlias": "instagram",
+            "identityProviderMapper": "hardcoded-role-idp-mapper",
+            "name": "instagram-user-role",
+            "config": {
+                "syncMode": "INHERIT",
+                "role": "customer"
+            }
+        },
+        {
+            "identityProviderAlias": "instagram",
+            "identityProviderMapper": "oauth2-user-attribute-idp-mapper",
+            "name": "instagram-username",
+            "config": {
+                "syncMode": "INHERIT",
+                "jsonField": "username",
+                "userAttribute": "username"
+            }
+        },
+        {
+            "identityProviderAlias": "instagram",
+            "identityProviderMapper": "oauth2-user-attribute-idp-mapper",
+            "name": "instagram-id-to-userid",
+            "config": {
+                "syncMode": "INHERIT",
+                "jsonField": "id",
+                "userAttribute": "userID"
+            }
+        }
+    ],
     "clients":  [
                     {
                         "clientId":  "admin-portal",

--- a/infrastructure/keycloak/realms/meajudaai-realm.dev.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.dev.json
@@ -41,7 +41,11 @@
                                 },
                                 {
                                     "name":  "meajudaai-system-admin",
-                                    "description":  "Administrador do sistema - todas as permissões"
+                                    "description":  "Administrador do sistema - todas as permissÃµes"
+                                },
+                                {
+                                    "name":  "meajudaai-super-admin",
+                                    "description":  "Super Administrador - acesso total irrestrito"
                                 },
                                 {
                                     "name":  "meajudaai-user-admin",

--- a/infrastructure/keycloak/realms/meajudaai-realm.dev.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.dev.json
@@ -41,7 +41,7 @@
                                 },
                                 {
                                     "name":  "meajudaai-system-admin",
-                                    "description":  "Administrador do sistema - todas as permissÃµes"
+                                    "description":  "Administrador do sistema - todas as permissões"
                                 },
                                 {
                                     "name":  "meajudaai-super-admin",

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -131,7 +131,7 @@
     {
       "alias": "instagram",
       "displayName": "Instagram",
-      "providerId": "oidc",
+      "providerId": "instagram",
       "enabled": true,
       "trustEmail": false,
       "storeToken": false,
@@ -140,12 +140,7 @@
       "firstBrokerLoginFlowAlias": "first broker login",
       "config": {
         "clientId": "${INSTAGRAM_CLIENT_ID}",
-        "clientSecret": "${INSTAGRAM_CLIENT_SECRET}",
-        "issuer": "https://api.instagram.com",
-        "authorizationUrl": "https://api.instagram.com/oauth/authorize",
-        "tokenUrl": "https://api.instagram.com/oauth/access_token",
-        "userInfoUrl": "https://graph.instagram.com/me",
-        "logoutUrl": "https://api.instagram.com/oauth/logout"
+        "clientSecret": "${INSTAGRAM_CLIENT_SECRET}"
       }
     }
   ],
@@ -294,7 +289,6 @@
       "serviceAccountClientId": "meajudaai-api-service",
       "clientRoles": {
         "realm-management": [
-          "realm-admin",
           "manage-users",
           "view-realm"
         ]

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -41,7 +41,11 @@
       },
       {
         "name": "meajudaai-system-admin",
-        "description": "Administrador do sistema - todas as permissões"
+        "description": "Administrador do sistema - todas as permissÃµes"
+      },
+      {
+        "name": "meajudaai-super-admin",
+        "description": "Super Administrador - acesso total irrestrito"
       },
       {
         "name": "meajudaai-user-admin",

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -132,7 +132,7 @@
       "alias": "instagram",
       "displayName": "Instagram",
       "providerId": "facebook",
-      "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API.",
+      "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API (OAuth2 puro, sem OIDC).",
       "enabled": true,
       "trustEmail": false,
       "storeToken": false,

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -131,8 +131,8 @@
     {
       "alias": "instagram",
       "displayName": "Instagram",
-      "providerId": "oidc",
-      "_comment": "Nota: O suporte nativo ao provedor Instagram foi removido no Keycloak 26.x. Utilizando OIDC genérico como alternativa conforme Issue #141.",
+      "providerId": "facebook",
+      "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API.",
       "enabled": true,
       "trustEmail": false,
       "storeToken": false,
@@ -142,11 +142,9 @@
       "config": {
         "clientId": "${INSTAGRAM_CLIENT_ID}",
         "clientSecret": "${INSTAGRAM_CLIENT_SECRET}",
-        "issuer": "https://api.instagram.com",
         "authorizationUrl": "https://api.instagram.com/oauth/authorize",
         "tokenUrl": "https://api.instagram.com/oauth/access_token",
-        "userInfoUrl": "https://graph.instagram.com/me",
-        "logoutUrl": "https://api.instagram.com/oauth/logout"
+        "userInfoUrl": "https://graph.instagram.com/me?fields=id,username"
       }
     }
   ],

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -131,7 +131,8 @@
     {
       "alias": "instagram",
       "displayName": "Instagram",
-      "providerId": "instagram",
+      "providerId": "oidc",
+      "_comment": "Nota: O suporte nativo ao provedor Instagram foi removido no Keycloak 26.x. Utilizando OIDC genérico como alternativa conforme Issue #141.",
       "enabled": true,
       "trustEmail": false,
       "storeToken": false,
@@ -140,7 +141,12 @@
       "firstBrokerLoginFlowAlias": "first broker login",
       "config": {
         "clientId": "${INSTAGRAM_CLIENT_ID}",
-        "clientSecret": "${INSTAGRAM_CLIENT_SECRET}"
+        "clientSecret": "${INSTAGRAM_CLIENT_SECRET}",
+        "issuer": "https://api.instagram.com",
+        "authorizationUrl": "https://api.instagram.com/oauth/authorize",
+        "tokenUrl": "https://api.instagram.com/oauth/access_token",
+        "userInfoUrl": "https://graph.instagram.com/me",
+        "logoutUrl": "https://api.instagram.com/oauth/logout"
       }
     }
   ],

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -41,7 +41,7 @@
       },
       {
         "name": "meajudaai-system-admin",
-        "description": "Administrador do sistema - todas as permissÃµes"
+        "description": "Administrador do sistema - todas as permissões"
       },
       {
         "name": "meajudaai-super-admin",
@@ -131,7 +131,7 @@
     {
       "alias": "instagram",
       "displayName": "Instagram",
-      "providerId": "instagram",
+      "providerId": "oidc",
       "enabled": true,
       "trustEmail": false,
       "storeToken": false,
@@ -140,7 +140,12 @@
       "firstBrokerLoginFlowAlias": "first broker login",
       "config": {
         "clientId": "${INSTAGRAM_CLIENT_ID}",
-        "clientSecret": "${INSTAGRAM_CLIENT_SECRET}"
+        "clientSecret": "${INSTAGRAM_CLIENT_SECRET}",
+        "issuer": "https://api.instagram.com",
+        "authorizationUrl": "https://api.instagram.com/oauth/authorize",
+        "tokenUrl": "https://api.instagram.com/oauth/access_token",
+        "userInfoUrl": "https://graph.instagram.com/me",
+        "logoutUrl": "https://api.instagram.com/oauth/logout"
       }
     }
   ],
@@ -192,7 +197,7 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
+      "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "protocol": "openid-connect",
       "redirectUris": [
@@ -232,7 +237,7 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
+      "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "protocol": "openid-connect",
       "redirectUris": [
@@ -282,5 +287,18 @@
       "authorizationServicesEnabled": false
     }
   ],
-  "users": []
+  "users": [
+    {
+      "username": "service-account-meajudaai-api-service",
+      "enabled": true,
+      "serviceAccountClientId": "meajudaai-api-service",
+      "clientRoles": {
+        "realm-management": [
+          "realm-admin",
+          "manage-users",
+          "view-realm"
+        ]
+      }
+    }
+  ]
 }

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -92,6 +92,22 @@
         "description": "Gerente de localidades - gerenciar cidades e estados"
       },
       {
+        "name": "meajudaai-provider-standard",
+        "description": "Prestador de serviços - Plano Standard (Gratuito)"
+      },
+      {
+        "name": "meajudaai-provider-silver",
+        "description": "Prestador de serviços - Plano Silver (Premium)"
+      },
+      {
+        "name": "meajudaai-provider-gold",
+        "description": "Prestador de serviços - Plano Gold (Premium Plus)"
+      },
+      {
+        "name": "meajudaai-provider-platinum",
+        "description": "Prestador de serviços - Plano Platinum (Elite)"
+      },
+      {
         "name": "customer",
         "description": "Cliente da plataforma"
       }
@@ -131,8 +147,8 @@
     {
       "alias": "instagram",
       "displayName": "Instagram",
-      "providerId": "facebook",
-      "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor do Facebook configurado para o Instagram Basic Display API (OAuth2 puro, sem OIDC).",
+      "providerId": "oauth2",
+      "_comment": "Nota: Suporte nativo ao Instagram removido no Keycloak 26.x. Utilizando o provedor OAuth2 genérico para garantir que as URLs da Basic Display API sejam respeitadas e contornar a ausência de OIDC discovery no Instagram.",
       "enabled": true,
       "trustEmail": false,
       "storeToken": false,
@@ -144,7 +160,41 @@
         "clientSecret": "${INSTAGRAM_CLIENT_SECRET}",
         "authorizationUrl": "https://api.instagram.com/oauth/authorize",
         "tokenUrl": "https://api.instagram.com/oauth/access_token",
-        "userInfoUrl": "https://graph.instagram.com/me?fields=id,username"
+        "userInfoUrl": "https://graph.instagram.com/me?fields=id,username",
+        "defaultScope": "user_profile",
+        "syncMode": "IMPORT",
+        "userIp": "false"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "identityProviderAlias": "instagram",
+      "identityProviderMapper": "hardcoded-role-idp-mapper",
+      "name": "instagram-user-role",
+      "config": {
+        "syncMode": "INHERIT",
+        "role": "customer"
+      }
+    },
+    {
+      "identityProviderAlias": "instagram",
+      "identityProviderMapper": "oauth2-user-attribute-idp-mapper",
+      "name": "instagram-username",
+      "config": {
+        "syncMode": "INHERIT",
+        "jsonField": "username",
+        "userAttribute": "username"
+      }
+    },
+    {
+      "identityProviderAlias": "instagram",
+      "identityProviderMapper": "oauth2-user-attribute-idp-mapper",
+      "name": "instagram-id-to-userid",
+      "config": {
+        "syncMode": "INHERIT",
+        "jsonField": "id",
+        "userAttribute": "userID"
       }
     }
   ],

--- a/infrastructure/keycloak/realms/meajudaai-realm.prod.json
+++ b/infrastructure/keycloak/realms/meajudaai-realm.prod.json
@@ -28,33 +28,64 @@
   "accountTheme": "meajudaai",
   "emailTheme": "meajudaai",
   "internationalizationEnabled": true,
-  "supportedLocales": ["pt-BR", "en"],
+  "supportedLocales": [
+    "pt-BR",
+    "en"
+  ],
   "defaultLocale": "pt-BR",
   "roles": {
     "realm": [
       {
         "name": "admin",
-        "description": "Administrador total da plataforma"
+        "description": "Administrador total da plataforma - todas as permissões"
       },
       {
-        "name": "provider-manager",
-        "description": "Gerente de provedores - pode criar, editar e deletar provedores"
+        "name": "meajudaai-system-admin",
+        "description": "Administrador do sistema - todas as permissões"
       },
       {
-        "name": "document-reviewer",
-        "description": "Revisor de documentos - pode revisar e aprovar documentos"
+        "name": "meajudaai-user-admin",
+        "description": "Administrador de usuários - gerenciar usuários"
       },
       {
-        "name": "catalog-manager",
-        "description": "Gerente de catálogo - pode gerenciar serviços e categorias"
+        "name": "meajudaai-user-operator",
+        "description": "Operador de usuários - leitura e atualização"
       },
       {
-        "name": "operator",
-        "description": "Operador com leitura/escrita limitada"
+        "name": "meajudaai-user",
+        "description": "Usuário básico - perfil próprio"
       },
       {
-        "name": "viewer",
-        "description": "Visualizador somente leitura"
+        "name": "meajudaai-provider-admin",
+        "description": "Administrador de prestadores - CRUD completo"
+      },
+      {
+        "name": "meajudaai-provider",
+        "description": "Prestador - apenas leitura"
+      },
+      {
+        "name": "meajudaai-order-admin",
+        "description": "Administrador de pedidos - CRUD completo"
+      },
+      {
+        "name": "meajudaai-order-operator",
+        "description": "Operador de pedidos - leitura e atualização"
+      },
+      {
+        "name": "meajudaai-report-admin",
+        "description": "Administrador de relatórios - criar e exportar"
+      },
+      {
+        "name": "meajudaai-report-viewer",
+        "description": "Visualizador de relatórios - apenas visualizar"
+      },
+      {
+        "name": "meajudaai-catalog-manager",
+        "description": "Gerente de catálogo - gerenciar serviços e categorias"
+      },
+      {
+        "name": "meajudaai-location-manager",
+        "description": "Gerente de localidades - gerenciar cidades e estados"
       },
       {
         "name": "customer",
@@ -62,6 +93,53 @@
       }
     ]
   },
+  "identityProviders": [
+    {
+      "alias": "google",
+      "displayName": "Google",
+      "providerId": "google",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "${GOOGLE_CLIENT_ID}",
+        "clientSecret": "${GOOGLE_CLIENT_SECRET}"
+      }
+    },
+    {
+      "alias": "facebook",
+      "displayName": "Facebook",
+      "providerId": "facebook",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "${FACEBOOK_APP_ID}",
+        "clientSecret": "${FACEBOOK_APP_SECRET}"
+      }
+    },
+    {
+      "alias": "instagram",
+      "displayName": "Instagram",
+      "providerId": "instagram",
+      "enabled": true,
+      "trustEmail": false,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "config": {
+        "clientId": "${INSTAGRAM_CLIENT_ID}",
+        "clientSecret": "${INSTAGRAM_CLIENT_SECRET}"
+      }
+    }
+  ],
   "clients": [
     {
       "clientId": "admin-portal",
@@ -110,7 +188,7 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
+      "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": false,
       "protocol": "openid-connect",
       "redirectUris": [
@@ -120,9 +198,84 @@
       "webOrigins": [
         "https://app.meajudaai.com.br"
       ],
+      "frontchannelLogout": true,
       "attributes": {
-        "pkce.code.challenge.method": "S256"
-      }
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "+"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "provider-app",
+      "name": "Provider App - Web + Mobile",
+      "description": "MeAjudaAi Provider App OIDC Client",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "redirectUris": [
+        "https://provider.meajudaai.com.br/*",
+        "meajudaai-provider://callback"
+      ],
+      "webOrigins": [
+        "https://provider.meajudaai.com.br"
+      ],
+      "frontchannelLogout": true,
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "+"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "meajudaai-api-service",
+      "name": "MeAjudaAi API Service Account",
+      "description": "Service account for API to access Keycloak Admin API",
+      "enabled": true,
+      "publicClient": false,
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "access.token.lifespan": "3600"
+      },
+      "secret": "${CLIENT_SECRET_MEAJUDAAI_API}",
+      "authorizationServicesEnabled": false
     }
   ],
   "users": []

--- a/src/Bootstrapper/MeAjudaAi.ApiService/Extensions/SecurityExtensions.cs
+++ b/src/Bootstrapper/MeAjudaAi.ApiService/Extensions/SecurityExtensions.cs
@@ -472,9 +472,16 @@ public static class SecurityExtensions
             .AddPolicy("SelfOrAdmin", policy =>
                 policy.AddRequirements(new SelfOrAdminRequirement()))
             .AddPolicy("AdminOnly", policy =>
-                policy.RequireRole("admin", "super-admin"))
+                policy.RequireRole(
+                    RoleConstants.Admin, 
+                    RoleConstants.SystemAdmin, 
+                    RoleConstants.SuperAdmin,
+                    RoleConstants.LegacySystemAdmin,
+                    RoleConstants.LegacySuperAdmin))
             .AddPolicy("SuperAdminOnly", policy =>
-                policy.RequireRole("super-admin"));
+                policy.RequireRole(
+                    RoleConstants.SuperAdmin,
+                    RoleConstants.LegacySuperAdmin));
 
         // Registra handlers de autorização customizados
         services.AddScoped<IAuthorizationHandler, SelfOrAdminHandler>();

--- a/src/Bootstrapper/MeAjudaAi.ApiService/Extensions/SecurityExtensions.cs
+++ b/src/Bootstrapper/MeAjudaAi.ApiService/Extensions/SecurityExtensions.cs
@@ -472,16 +472,9 @@ public static class SecurityExtensions
             .AddPolicy("SelfOrAdmin", policy =>
                 policy.AddRequirements(new SelfOrAdminRequirement()))
             .AddPolicy("AdminOnly", policy =>
-                policy.RequireRole(
-                    RoleConstants.Admin, 
-                    RoleConstants.SystemAdmin, 
-                    RoleConstants.SuperAdmin,
-                    RoleConstants.LegacySystemAdmin,
-                    RoleConstants.LegacySuperAdmin))
+                policy.RequireRole(RoleConstants.AdminEquivalentRoles))
             .AddPolicy("SuperAdminOnly", policy =>
-                policy.RequireRole(
-                    RoleConstants.SuperAdmin,
-                    RoleConstants.LegacySuperAdmin));
+                policy.RequireRole(RoleConstants.SuperAdminEquivalentRoles));
 
         // Registra handlers de autorização customizados
         services.AddScoped<IAuthorizationHandler, SelfOrAdminHandler>();

--- a/src/Bootstrapper/MeAjudaAi.ApiService/Extensions/SecurityExtensions.cs
+++ b/src/Bootstrapper/MeAjudaAi.ApiService/Extensions/SecurityExtensions.cs
@@ -492,7 +492,18 @@ public static class SecurityExtensions
     {
         var roleClaims = new List<Claim>();
 
-        // Extrai roles do realm_access
+        // 1. Extrai roles da claim raiz 'roles' (suportada por mappers customizados como o realm-roles)
+        if (jwtToken.Payload.TryGetValue("roles", out var rootRolesObj) &&
+            rootRolesObj is IEnumerable<object> rootRolesList)
+        {
+            foreach (var role in rootRolesList.OfType<string>())
+            {
+                if (!roleClaims.Any(c => c.Value == role))
+                    roleClaims.Add(new Claim(ClaimTypes.Role, role));
+            }
+        }
+
+        // 2. Extrai roles do realm_access (padrão do Keycloak)
         if (jwtToken.Payload.TryGetValue("realm_access", out var realmObj) &&
             realmObj is IDictionary<string, object> realmDict &&
             realmDict.TryGetValue("roles", out var realmRoles) &&
@@ -500,11 +511,12 @@ public static class SecurityExtensions
         {
             foreach (var role in realmRolesList.OfType<string>())
             {
-                roleClaims.Add(new Claim(ClaimTypes.Role, role));
+                if (!roleClaims.Any(c => c.Value == role))
+                    roleClaims.Add(new Claim(ClaimTypes.Role, role));
             }
         }
 
-        // Extrai roles do resource_access para o cliente específico
+        // 3. Extrai roles do resource_access para o cliente específico
         if (jwtToken.Payload.TryGetValue("resource_access", out var resourceObj) &&
             resourceObj is IDictionary<string, object> resourceDict &&
             resourceDict.TryGetValue(clientId, out var clientObj) &&
@@ -514,7 +526,8 @@ public static class SecurityExtensions
         {
             foreach (var role in clientRolesList.OfType<string>())
             {
-                roleClaims.Add(new Claim(ClaimTypes.Role, role));
+                if (!roleClaims.Any(c => c.Value == role))
+                    roleClaims.Add(new Claim(ClaimTypes.Role, role));
             }
         }
 

--- a/src/Bootstrapper/MeAjudaAi.ApiService/Handlers/SelfOrAdminHandler.cs
+++ b/src/Bootstrapper/MeAjudaAi.ApiService/Handlers/SelfOrAdminHandler.cs
@@ -1,4 +1,7 @@
+using MeAjudaAi.Shared.Utilities.Constants;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
 
 namespace MeAjudaAi.ApiService.Handlers;
 
@@ -10,38 +13,36 @@ public class SelfOrAdminHandler : AuthorizationHandler<SelfOrAdminRequirement>
         AuthorizationHandlerContext context,
         SelfOrAdminRequirement requirement)
     {
-        // Se o usuário não está autenticado, falha imediatamente
-        if (!context.User.Identity?.IsAuthenticated ?? true)
+        // 1. Se o usuário não está autenticado, falha imediatamente
+        if (context.User.Identity?.IsAuthenticated != true)
         {
             context.Fail();
             return Task.CompletedTask;
         }
 
-        var userIdClaim = context.User.FindFirst(MeAjudaAi.Shared.Utilities.Constants.AuthConstants.Claims.Subject)?.Value 
-                          ?? context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
-        
-        var roles = context.User.FindAll(MeAjudaAi.Shared.Utilities.Constants.AuthConstants.Claims.Roles)
-            .Concat(context.User.FindAll(System.Security.Claims.ClaimTypes.Role))
+        // 2. Extrai todas as roles de forma robusta (suporta 'roles' e ClaimTypes.Role)
+        var userRoles = context.User.FindAll(AuthConstants.Claims.Roles)
+            .Concat(context.User.FindAll(ClaimTypes.Role))
             .Select(c => c.Value)
             .Distinct();
 
-        // Verifica se o usuário é admin
-        if (roles.Any(r =>
-            string.Equals(r, MeAjudaAi.Shared.Utilities.UserRoles.Admin, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(r, MeAjudaAi.Shared.Utilities.UserRoles.SuperAdmin, StringComparison.OrdinalIgnoreCase)))
+        // 3. Verifica se o usuário é admin
+        if (userRoles.Any(role => RoleConstants.AdminEquivalentRoles.Contains(role, StringComparer.OrdinalIgnoreCase)))
         {
             context.Succeed(requirement);
             return Task.CompletedTask;
         }
 
-        // Verifica se está acessando o próprio recurso
+        // 4. Verifica se está acessando o próprio recurso (validação de ID)
         if (context.Resource is HttpContext httpContext)
         {
-            var routeUserId = httpContext.GetRouteValue("id")?.ToString()
-                               ?? httpContext.GetRouteValue("userId")?.ToString()
+            var userIdClaim = context.User.FindFirst(AuthConstants.Claims.Subject)?.Value 
+                              ?? context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            var routeUserId = httpContext.GetRouteValue("userId")?.ToString()
+                               ?? httpContext.GetRouteValue("id")?.ToString()
                                ?? httpContext.GetRouteValue("providerId")?.ToString();
 
-            // Só permite acesso se ambos os IDs estão presentes e são iguais
             if (!string.IsNullOrWhiteSpace(userIdClaim) &&
                 !string.IsNullOrWhiteSpace(routeUserId) &&
                 string.Equals(userIdClaim, routeUserId, StringComparison.OrdinalIgnoreCase))
@@ -51,7 +52,7 @@ public class SelfOrAdminHandler : AuthorizationHandler<SelfOrAdminRequirement>
             }
         }
 
-        // Se chegou até aqui, o usuário não tem permissão
+        // 5. Se nenhuma condição foi atendida, falha explicitamente
         context.Fail();
         return Task.CompletedTask;
     }

--- a/src/Modules/Documents/Application/Handlers/ApproveDocumentCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/ApproveDocumentCommandHandler.cs
@@ -50,9 +50,7 @@ public class ApproveDocumentCommandHandler(
             if (user == null || user.Identity == null || !user.Identity.IsAuthenticated)
                 throw new UnauthorizedAccessException("É necessário estar autenticado para aprovar documentos");
 
-            var isAdmin = user.IsInRole(RoleConstants.Admin) || 
-                          user.IsInRole(RoleConstants.SystemAdmin) ||
-                          user.IsInRole(RoleConstants.LegacySystemAdmin);
+            var isAdmin = RoleConstants.AdminEquivalentRoles.Any(user.IsInRole);
             if (!isAdmin)
             {
                 var userId = user.FindFirst("sub")?.Value ?? user.FindFirst("id")?.Value;

--- a/src/Modules/Documents/Application/Handlers/ApproveDocumentCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/ApproveDocumentCommandHandler.cs
@@ -8,6 +8,7 @@ using MeAjudaAi.Shared.Exceptions;
 using MeAjudaAi.Contracts.Functional;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using MeAjudaAi.Shared.Utilities.Constants;
 
 namespace MeAjudaAi.Modules.Documents.Application.Handlers;
 
@@ -49,7 +50,9 @@ public class ApproveDocumentCommandHandler(
             if (user == null || user.Identity == null || !user.Identity.IsAuthenticated)
                 throw new UnauthorizedAccessException("É necessário estar autenticado para aprovar documentos");
 
-            var isAdmin = user.IsInRole("admin") || user.IsInRole("system-admin");
+            var isAdmin = user.IsInRole(RoleConstants.Admin) || 
+                          user.IsInRole(RoleConstants.SystemAdmin) ||
+                          user.IsInRole(RoleConstants.LegacySystemAdmin);
             if (!isAdmin)
             {
                 var userId = user.FindFirst("sub")?.Value ?? user.FindFirst("id")?.Value;

--- a/src/Modules/Documents/Application/Handlers/RejectDocumentCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/RejectDocumentCommandHandler.cs
@@ -7,6 +7,7 @@ using MeAjudaAi.Shared.Exceptions;
 using MeAjudaAi.Contracts.Functional;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using MeAjudaAi.Shared.Utilities.Constants;
 
 namespace MeAjudaAi.Modules.Documents.Application.Handlers;
 
@@ -48,7 +49,9 @@ public class RejectDocumentCommandHandler(
             if (user == null || user.Identity == null || !user.Identity.IsAuthenticated)
                 throw new UnauthorizedAccessException("User is not authenticated");
 
-            var isAdmin = user.IsInRole("admin") || user.IsInRole("system-admin");
+            var isAdmin = user.IsInRole(RoleConstants.Admin) || 
+                          user.IsInRole(RoleConstants.SystemAdmin) ||
+                          user.IsInRole(RoleConstants.LegacySystemAdmin);
             if (!isAdmin)
             {
                 var userId = user.FindFirst("sub")?.Value ?? user.FindFirst("id")?.Value;

--- a/src/Modules/Documents/Application/Handlers/RejectDocumentCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/RejectDocumentCommandHandler.cs
@@ -49,9 +49,7 @@ public class RejectDocumentCommandHandler(
             if (user == null || user.Identity == null || !user.Identity.IsAuthenticated)
                 throw new UnauthorizedAccessException("User is not authenticated");
 
-            var isAdmin = user.IsInRole(RoleConstants.Admin) || 
-                          user.IsInRole(RoleConstants.SystemAdmin) ||
-                          user.IsInRole(RoleConstants.LegacySystemAdmin);
+            var isAdmin = RoleConstants.AdminEquivalentRoles.Any(user.IsInRole);
             if (!isAdmin)
             {
                 var userId = user.FindFirst("sub")?.Value ?? user.FindFirst("id")?.Value;

--- a/src/Modules/Documents/Application/Handlers/RequestVerificationCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/RequestVerificationCommandHandler.cs
@@ -7,6 +7,7 @@ using MeAjudaAi.Contracts.Functional;
 using MeAjudaAi.Shared.Jobs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using MeAjudaAi.Shared.Utilities.Constants;
 
 namespace MeAjudaAi.Modules.Documents.Application.Handlers;
 
@@ -58,7 +59,9 @@ public class RequestVerificationCommandHandler(
             if (!Guid.TryParse(userId, out var userGuid) || userGuid != document.ProviderId)
             {
                 // Verificar se o usuário possui o papel de administrador
-                var isAdmin = user.IsInRole("admin") || user.IsInRole("system-admin");
+                var isAdmin = user.IsInRole(RoleConstants.Admin) || 
+                              user.IsInRole(RoleConstants.SystemAdmin) ||
+                              user.IsInRole(RoleConstants.LegacySystemAdmin);
                 if (!isAdmin)
                 {
                     _logger.LogWarning(

--- a/src/Modules/Documents/Application/Handlers/RequestVerificationCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/RequestVerificationCommandHandler.cs
@@ -59,9 +59,7 @@ public class RequestVerificationCommandHandler(
             if (!Guid.TryParse(userId, out var userGuid) || userGuid != document.ProviderId)
             {
                 // Verificar se o usuário possui o papel de administrador
-                var isAdmin = user.IsInRole(RoleConstants.Admin) || 
-                              user.IsInRole(RoleConstants.SystemAdmin) ||
-                              user.IsInRole(RoleConstants.LegacySystemAdmin);
+                var isAdmin = RoleConstants.AdminEquivalentRoles.Any(user.IsInRole);
                 if (!isAdmin)
                 {
                     _logger.LogWarning(

--- a/src/Modules/Documents/Application/Handlers/UploadDocumentCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/UploadDocumentCommandHandler.cs
@@ -61,9 +61,7 @@ public class UploadDocumentCommandHandler(
             if (!Guid.TryParse(userId, out var userGuid) || userGuid != command.ProviderId)
             {
                 // Verificar se o usuário possui o papel de administrador
-                var isAdmin = user.IsInRole(RoleConstants.Admin) || 
-                              user.IsInRole(RoleConstants.SystemAdmin) ||
-                              user.IsInRole(RoleConstants.LegacySystemAdmin);
+                var isAdmin = RoleConstants.AdminEquivalentRoles.Any(user.IsInRole);
                 if (!isAdmin)
                 {
                     _logger.LogWarning(

--- a/src/Modules/Documents/Application/Handlers/UploadDocumentCommandHandler.cs
+++ b/src/Modules/Documents/Application/Handlers/UploadDocumentCommandHandler.cs
@@ -12,6 +12,7 @@ using MeAjudaAi.Shared.Jobs;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MeAjudaAi.Shared.Utilities.Constants;
 
 namespace MeAjudaAi.Modules.Documents.Application.Handlers;
 
@@ -60,7 +61,9 @@ public class UploadDocumentCommandHandler(
             if (!Guid.TryParse(userId, out var userGuid) || userGuid != command.ProviderId)
             {
                 // Verificar se o usuário possui o papel de administrador
-                var isAdmin = user.IsInRole("admin") || user.IsInRole("system-admin");
+                var isAdmin = user.IsInRole(RoleConstants.Admin) || 
+                              user.IsInRole(RoleConstants.SystemAdmin) ||
+                              user.IsInRole(RoleConstants.LegacySystemAdmin);
                 if (!isAdmin)
                 {
                     _logger.LogWarning(

--- a/src/Modules/Documents/Tests/Unit/Application/ApproveDocumentCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/ApproveDocumentCommandHandlerTests.cs
@@ -47,8 +47,13 @@ public class ApproveDocumentCommandHandlerTests
 
     private void SetupAuthenticatedAdmin() => SetupAuthenticatedUser(RoleConstants.Admin);
 
-    [Fact]
-    public async Task HandleAsync_WithValidDocument_ShouldApproveDocument()
+    [Theory]
+    [InlineData(RoleConstants.Admin)]
+    [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.LegacySuperAdmin)]
+    public async Task HandleAsync_WithAdminUser_ShouldApproveDocument(string adminRole)
     {
         // Arrange
         var documentId = Guid.NewGuid();
@@ -62,7 +67,7 @@ public class ApproveDocumentCommandHandlerTests
             "blob-key-123");
         document.MarkAsPendingVerification();
 
-        SetupAuthenticatedAdmin();
+        SetupAuthenticatedUser(adminRole);
 
         _mockRepository
             .Setup(x => x.GetByIdAsync(documentId, It.IsAny<CancellationToken>()))
@@ -85,12 +90,7 @@ public class ApproveDocumentCommandHandlerTests
         result.Should().NotBeNull();
         result.IsSuccess.Should().BeTrue();
         document.Status.Should().Be(EDocumentStatus.Verified);
-        document.OcrData.Should().NotBeNullOrEmpty();
         
-        // Validate JSON structure
-        var ocrJson = JsonSerializer.Deserialize<JsonElement>(document.OcrData!);
-        ocrJson.GetProperty("notes").GetString().Should().Be(verificationNotes);
-
         _mockRepository.Verify(
             x => x.UpdateAsync(It.Is<Document>(d => d.Status == EDocumentStatus.Verified), It.IsAny<CancellationToken>()),
             Times.Once);
@@ -194,46 +194,6 @@ public class ApproveDocumentCommandHandlerTests
 
         // Assert
         result.Should().NotBeNull();
-        result.IsSuccess.Should().BeTrue();
-        document.Status.Should().Be(EDocumentStatus.Verified);
-        document.OcrData.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task HandleAsync_WithSystemAdminUser_ShouldApproveDocument()
-    {
-        // Arrange
-        var documentId = Guid.NewGuid();
-        var providerId = Guid.NewGuid();
-
-        var document = Document.Create(
-            providerId,
-            EDocumentType.IdentityDocument,
-            "identity.pdf",
-            "blob-key-123");
-        document.MarkAsPendingVerification();
-
-        // Setup system-admin user
-        SetupAuthenticatedUser(RoleConstants.SystemAdmin);
-
-        _mockRepository
-            .Setup(x => x.GetByIdAsync(documentId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(document);
-
-        _mockRepository
-            .Setup(x => x.UpdateAsync(It.IsAny<Document>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        _mockRepository
-            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        var command = new ApproveDocumentCommand(documentId, null);
-
-        // Act
-        var result = await _handler.HandleAsync(command);
-
-        // Assert
         result.IsSuccess.Should().BeTrue();
         document.Status.Should().Be(EDocumentStatus.Verified);
         document.OcrData.Should().BeNull();

--- a/src/Modules/Documents/Tests/Unit/Application/ApproveDocumentCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/ApproveDocumentCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public class ApproveDocumentCommandHandlerTests
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
     }
 
-    private void SetupAuthenticatedAdmin() => SetupAuthenticatedUser("admin");
+    private void SetupAuthenticatedAdmin() => SetupAuthenticatedUser(RoleConstants.Admin);
 
     [Fact]
     public async Task HandleAsync_WithValidDocument_ShouldApproveDocument()
@@ -214,7 +214,7 @@ public class ApproveDocumentCommandHandlerTests
         document.MarkAsPendingVerification();
 
         // Setup system-admin user
-        SetupAuthenticatedUser("system-admin");
+        SetupAuthenticatedUser(RoleConstants.SystemAdmin);
 
         _mockRepository
             .Setup(x => x.GetByIdAsync(documentId, It.IsAny<CancellationToken>()))

--- a/src/Modules/Documents/Tests/Unit/Application/RejectDocumentCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/RejectDocumentCommandHandlerTests.cs
@@ -30,12 +30,12 @@ public class RejectDocumentCommandHandlerTests
             _mockLogger.Object);
     }
 
-    private void SetupAuthenticatedAdmin()
+    private void SetupAuthenticatedUser(string role)
     {
         var claims = new List<Claim>
         {
             new(AuthConstants.Claims.Subject, Guid.NewGuid().ToString()),
-            new(ClaimTypes.Role, RoleConstants.Admin)
+            new(ClaimTypes.Role, role)
         };
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);
@@ -44,8 +44,15 @@ public class RejectDocumentCommandHandlerTests
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
     }
 
-    [Fact]
-    public async Task HandleAsync_WithValidDocument_ShouldRejectDocument()
+    private void SetupAuthenticatedAdmin() => SetupAuthenticatedUser(RoleConstants.Admin);
+
+    [Theory]
+    [InlineData(RoleConstants.Admin)]
+    [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.LegacySuperAdmin)]
+    public async Task HandleAsync_WithAdminUser_ShouldRejectDocument(string adminRole)
     {
         var documentId = Guid.NewGuid();
         var providerId = Guid.NewGuid();
@@ -54,7 +61,7 @@ public class RejectDocumentCommandHandlerTests
         var document = Document.Create(providerId, EDocumentType.IdentityDocument, "identity.pdf", "blob-key-123");
         document.MarkAsPendingVerification();
 
-        SetupAuthenticatedAdmin();
+        SetupAuthenticatedUser(adminRole);
 
         _mockRepository.Setup(x => x.GetByIdAsync(documentId, It.IsAny<CancellationToken>())).ReturnsAsync(document);
         _mockRepository.Setup(x => x.UpdateAsync(It.IsAny<Document>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);

--- a/src/Modules/Documents/Tests/Unit/Application/RejectDocumentCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/RejectDocumentCommandHandlerTests.cs
@@ -35,7 +35,7 @@ public class RejectDocumentCommandHandlerTests
         var claims = new List<Claim>
         {
             new(AuthConstants.Claims.Subject, Guid.NewGuid().ToString()),
-            new(ClaimTypes.Role, "admin")
+            new(ClaimTypes.Role, RoleConstants.Admin)
         };
         var identity = new ClaimsIdentity(claims, "TestAuth");
         var principal = new ClaimsPrincipal(identity);

--- a/src/Modules/Documents/Tests/Unit/Application/RequestVerificationCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/RequestVerificationCommandHandlerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using MeAjudaAi.Shared.Utilities.Constants;
 
 namespace MeAjudaAi.Modules.Documents.Tests.Unit.Application;
 
@@ -142,7 +143,7 @@ public class RequestVerificationCommandHandlerTests
         {
             new Claim("sub", adminUserId.ToString()),
             new Claim(ClaimTypes.Name, "admin-user"),
-            new Claim(ClaimTypes.Role, "admin")
+            new Claim(ClaimTypes.Role, RoleConstants.Admin)
         };
         var identity = new ClaimsIdentity(claims, "TestAuth");
         httpContext.User = new ClaimsPrincipal(identity);

--- a/src/Modules/Documents/Tests/Unit/Application/RequestVerificationCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/RequestVerificationCommandHandlerTests.cs
@@ -124,8 +124,13 @@ public class RequestVerificationCommandHandlerTests
         _mockRepository.Verify(x => x.UpdateAsync(It.IsAny<Document>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
-    [Fact]
-    public async Task HandleAsync_WithAdminUser_ShouldAllowVerificationForAnyDocument()
+    [Theory]
+    [InlineData(RoleConstants.Admin)]
+    [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.LegacySuperAdmin)]
+    public async Task HandleAsync_WithAdminUser_ShouldAllowVerificationForAnyDocument(string adminRole)
     {
         // Arrange
         var documentId = Guid.NewGuid();
@@ -143,7 +148,7 @@ public class RequestVerificationCommandHandlerTests
         {
             new Claim("sub", adminUserId.ToString()),
             new Claim(ClaimTypes.Name, "admin-user"),
-            new Claim(ClaimTypes.Role, RoleConstants.Admin)
+            new Claim(ClaimTypes.Role, adminRole)
         };
         var identity = new ClaimsIdentity(claims, "TestAuth");
         httpContext.User = new ClaimsPrincipal(identity);

--- a/src/Modules/Documents/Tests/Unit/Application/RequestVerificationCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/RequestVerificationCommandHandlerTests.cs
@@ -150,7 +150,8 @@ public class RequestVerificationCommandHandlerTests
             new Claim(ClaimTypes.Name, "admin-user"),
             new Claim(ClaimTypes.Role, adminRole)
         };
-        var identity = new ClaimsIdentity(claims, "TestAuth");
+        // Especificar explicitamente o RoleClaimType como ClaimTypes.Role
+        var identity = new ClaimsIdentity(claims, "TestAuth", "sub", ClaimTypes.Role);
         httpContext.User = new ClaimsPrincipal(identity);
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 

--- a/src/Modules/Documents/Tests/Unit/Application/UploadDocumentCommandHandlerTests.cs
+++ b/src/Modules/Documents/Tests/Unit/Application/UploadDocumentCommandHandlerTests.cs
@@ -365,7 +365,7 @@ public class UploadDocumentCommandHandlerTests
         // Arrange
         var providerId = Guid.NewGuid();
         var adminUserId = Guid.NewGuid();
-        SetupAuthenticatedUser(adminUserId, "admin"); // Admin user with different ID
+        SetupAuthenticatedUser(adminUserId, RoleConstants.Admin); // Admin user with different ID
 
         var command = new UploadDocumentCommand(
             providerId,
@@ -414,7 +414,7 @@ public class UploadDocumentCommandHandlerTests
         // Arrange
         var providerId = Guid.NewGuid();
         var systemAdminUserId = Guid.NewGuid();
-        SetupAuthenticatedUser(systemAdminUserId, "system-admin"); // System admin
+        SetupAuthenticatedUser(systemAdminUserId, RoleConstants.SystemAdmin); // System admin
 
         var command = new UploadDocumentCommand(
             providerId,

--- a/src/Shared/Utilities/Constants/RoleConstants.cs
+++ b/src/Shared/Utilities/Constants/RoleConstants.cs
@@ -12,6 +12,7 @@ public static class RoleConstants
     // Roles de sistema/admin
     public const string Admin = "admin";
     public const string SystemAdmin = "meajudaai-system-admin";
+    public const string SuperAdmin = "meajudaai-super-admin";
 
     // Roles de usuários
     public const string UserAdmin = "meajudaai-user-admin";
@@ -35,4 +36,8 @@ public static class RoleConstants
 
     // Roles de localização
     public const string LocationManager = "meajudaai-location-manager";
+
+    // Roles legadas para compatibilidade (remover após transição completa)
+    public const string LegacySystemAdmin = "system-admin";
+    public const string LegacySuperAdmin = "super-admin";
 }

--- a/src/Shared/Utilities/Constants/RoleConstants.cs
+++ b/src/Shared/Utilities/Constants/RoleConstants.cs
@@ -40,4 +40,25 @@ public static class RoleConstants
     // Roles legadas para compatibilidade (remover após transição completa)
     public const string LegacySystemAdmin = "system-admin";
     public const string LegacySuperAdmin = "super-admin";
+
+    /// <summary>
+    /// Lista de roles equivalentes a administrador para verificações de segurança.
+    /// </summary>
+    public static readonly string[] AdminEquivalentRoles = 
+    [
+        Admin,
+        SystemAdmin,
+        SuperAdmin,
+        LegacySystemAdmin,
+        LegacySuperAdmin
+    ];
+
+    /// <summary>
+    /// Lista de roles equivalentes a super-administrador.
+    /// </summary>
+    public static readonly string[] SuperAdminEquivalentRoles = 
+    [
+        SuperAdmin,
+        LegacySuperAdmin
+    ];
 }

--- a/src/Shared/Utilities/UserRoles.cs
+++ b/src/Shared/Utilities/UserRoles.cs
@@ -39,14 +39,19 @@ public static class UserRoles
     public const string Operator = RoleConstants.UserOperator;
 
     /// <summary>
-    /// Visualizador - acesso somente leitura
+    /// Visualizador de relatórios - acesso somente leitura
     /// </summary>
-    public const string Viewer = "meajudaai-viewer"; // Novo padrão
+    public const string ReportViewer = RoleConstants.ReportViewer;
 
     /// <summary>
     /// Papel de cliente para contas de usuário final (Customer App)
     /// </summary>
     public const string Customer = "customer";
+
+    /// <summary>
+    /// Papel base para prestadores de serviços.
+    /// </summary>
+    public const string Provider = RoleConstants.Provider;
 
     // ===== PROVIDER TIER ROLES =====
     // Gerenciados automaticamente via webhook Stripe (módulo de pagamentos futuro).
@@ -84,8 +89,9 @@ public static class UserRoles
         DocumentReviewer,
         CatalogManager,
         Operator,
-        Viewer,
+        ReportViewer,
         Customer,
+        Provider,
         ProviderStandard,
         ProviderSilver,
         ProviderGold,
@@ -102,7 +108,8 @@ public static class UserRoles
         ProviderManager,
         DocumentReviewer,
         CatalogManager,
-        Operator
+        Operator,
+        ReportViewer
     ];
 
     /// <summary>
@@ -118,6 +125,7 @@ public static class UserRoles
     /// </summary>
     public static readonly string[] ProviderRoles =
     [
+        Provider,
         ProviderStandard,
         ProviderSilver,
         ProviderGold,

--- a/src/Shared/Utilities/UserRoles.cs
+++ b/src/Shared/Utilities/UserRoles.cs
@@ -1,44 +1,47 @@
+using MeAjudaAi.Shared.Utilities.Constants;
+
 namespace MeAjudaAi.Shared.Utilities;
 
 /// <summary>
-/// Papéis do sistema para autorização e controle de acesso
+/// Papéis do sistema para autorização e controle de acesso.
+/// Centraliza a lógica de agrupamento de papéis usando as constantes canônicas de RoleConstants.
 /// </summary>
 public static class UserRoles
 {
     /// <summary>
     /// Super Administrador - acesso irrestrito ao sistema inteiro
     /// </summary>
-    public const string SuperAdmin = "super-admin";
+    public const string SuperAdmin = RoleConstants.SuperAdmin;
 
     /// <summary>
     /// Administrador com permissões elevadas - acesso total ao Admin Portal
     /// </summary>
-    public const string Admin = "admin";
+    public const string Admin = RoleConstants.SystemAdmin;
 
     /// <summary>
     /// Gerente de provedores - pode criar, editar e deletar provedores
     /// </summary>
-    public const string ProviderManager = "provider-manager";
+    public const string ProviderManager = RoleConstants.ProviderAdmin;
 
     /// <summary>
     /// Revisor de documentos - pode revisar e aprovar documentos
     /// </summary>
-    public const string DocumentReviewer = "document-reviewer";
+    public const string DocumentReviewer = RoleConstants.LegacySystemAdmin; // Mapeado para legacy até migração total
 
     /// <summary>
     /// Gerente de catálogo - pode gerenciar serviços e categorias
     /// </summary>
-    public const string CatalogManager = "catalog-manager";
+    public const string CatalogManager = RoleConstants.CatalogManager;
 
     /// <summary>
     /// Operador com leitura/escrita limitada
     /// </summary>
-    public const string Operator = "operator";
+    public const string Operator = RoleConstants.UserOperator;
 
     /// <summary>
     /// Visualizador - acesso somente leitura
     /// </summary>
-    public const string Viewer = "viewer";
+    public const string Viewer = "meajudaai-viewer"; // Novo padrão
 
     /// <summary>
     /// Papel de cliente para contas de usuário final (Customer App)
@@ -53,22 +56,22 @@ public static class UserRoles
     /// Prestador de serviços no plano gratuito (Standard).
     /// Atribuído automaticamente no auto-registro.
     /// </summary>
-    public const string ProviderStandard = "provider-standard";
+    public const string ProviderStandard = "meajudaai-provider-standard";
 
     /// <summary>
     /// Prestador de serviços no plano Silver (pago via Stripe).
     /// </summary>
-    public const string ProviderSilver = "provider-silver";
+    public const string ProviderSilver = "meajudaai-provider-silver";
 
     /// <summary>
     /// Prestador de serviços no plano Gold (pago via Stripe).
     /// </summary>
-    public const string ProviderGold = "provider-gold";
+    public const string ProviderGold = "meajudaai-provider-gold";
 
     /// <summary>
     /// Prestador de serviços no plano Platinum (pago via Stripe).
     /// </summary>
-    public const string ProviderPlatinum = "provider-platinum";
+    public const string ProviderPlatinum = "meajudaai-provider-platinum";
 
     /// <summary>
     /// Obtém todos os papéis disponíveis no sistema
@@ -144,6 +147,8 @@ public static class UserRoles
     /// <summary>
     /// Valida se um papel é de prestador de serviços (qualquer tier)
     /// </summary>
+    /// <param name="role">Papel a ser verificado</param>
+    /// <returns>True se o papel for de prestador, false caso contrário</returns>
     public static bool IsProviderRole(string role)
     {
         return ProviderRoles.Contains(role, StringComparer.OrdinalIgnoreCase);

--- a/src/Shared/Utilities/UserRoles.cs
+++ b/src/Shared/Utilities/UserRoles.cs
@@ -9,119 +9,150 @@ namespace MeAjudaAi.Shared.Utilities;
 public static class UserRoles
 {
     /// <summary>
-    /// Super Administrador - acesso irrestrito ao sistema inteiro
+    /// Papel legado 'admin' (Keycloak default).
+    /// </summary>
+    public const string AdminLegacy = RoleConstants.Admin;
+
+    /// <summary>
+    /// Administrador do sistema - acesso total às configurações e logs.
+    /// </summary>
+    public const string SystemAdmin = RoleConstants.SystemAdmin;
+
+    /// <summary>
+    /// Super Administrador - acesso irrestrito ao sistema inteiro.
     /// </summary>
     public const string SuperAdmin = RoleConstants.SuperAdmin;
 
     /// <summary>
-    /// Administrador com permissões elevadas - acesso total ao Admin Portal
+    /// Administrador de usuários - pode gerenciar contas e permissões.
     /// </summary>
-    public const string Admin = RoleConstants.SystemAdmin;
+    public const string UserAdmin = RoleConstants.UserAdmin;
 
     /// <summary>
-    /// Gerente de provedores - pode criar, editar e deletar provedores
+    /// Operador de usuários - leitura e atualização limitada de perfis.
     /// </summary>
-    public const string ProviderManager = RoleConstants.ProviderAdmin;
+    public const string UserOperator = RoleConstants.UserOperator;
 
     /// <summary>
-    /// Revisor de documentos - pode revisar e aprovar documentos
+    /// Usuário básico do sistema.
     /// </summary>
-    public const string DocumentReviewer = RoleConstants.LegacySystemAdmin; // Mapeado para legacy até migração total
+    public const string User = RoleConstants.User;
 
     /// <summary>
-    /// Gerente de catálogo - pode gerenciar serviços e categorias
+    /// Administrador de prestadores - CRUD completo de perfis de serviço.
     /// </summary>
-    public const string CatalogManager = RoleConstants.CatalogManager;
+    public const string ProviderAdmin = RoleConstants.ProviderAdmin;
 
     /// <summary>
-    /// Operador com leitura/escrita limitada
+    /// Prestador de serviços - acesso ao painel do prestador.
     /// </summary>
-    public const string Operator = RoleConstants.UserOperator;
+    public const string Provider = RoleConstants.Provider;
 
     /// <summary>
-    /// Visualizador de relatórios - acesso somente leitura
+    /// Administrador de pedidos - gerenciar transações e fluxos de serviço.
+    /// </summary>
+    public const string OrderAdmin = RoleConstants.OrderAdmin;
+
+    /// <summary>
+    /// Operador de pedidos - leitura e atualização de status de serviço.
+    /// </summary>
+    public const string OrderOperator = RoleConstants.OrderOperator;
+
+    /// <summary>
+    /// Administrador de relatórios - criar e exportar dados estatísticos.
+    /// </summary>
+    public const string ReportAdmin = RoleConstants.ReportAdmin;
+
+    /// <summary>
+    /// Visualizador de relatórios - acesso somente leitura a dashboards.
     /// </summary>
     public const string ReportViewer = RoleConstants.ReportViewer;
 
     /// <summary>
-    /// Papel de cliente para contas de usuário final (Customer App)
+    /// Gerente de catálogo - gerenciar serviços e categorias.
+    /// </summary>
+    public const string CatalogManager = RoleConstants.CatalogManager;
+
+    /// <summary>
+    /// Gerente de localidades - gerenciar cidades e estados atendidos.
+    /// </summary>
+    public const string LocationManager = RoleConstants.LocationManager;
+
+    /// <summary>
+    /// Papel de cliente para contas de usuário final (Customer App).
     /// </summary>
     public const string Customer = "customer";
 
-    /// <summary>
-    /// Papel base para prestadores de serviços.
-    /// </summary>
-    public const string Provider = RoleConstants.Provider;
-
     // ===== PROVIDER TIER ROLES =====
-    // Gerenciados automaticamente via webhook Stripe (módulo de pagamentos futuro).
-    // Todo prestador começa como provider-standard (plano gratuito).
-
+    
     /// <summary>
     /// Prestador de serviços no plano gratuito (Standard).
-    /// Atribuído automaticamente no auto-registro.
     /// </summary>
     public const string ProviderStandard = "meajudaai-provider-standard";
 
     /// <summary>
-    /// Prestador de serviços no plano Silver (pago via Stripe).
+    /// Prestador de serviços no plano Silver.
     /// </summary>
     public const string ProviderSilver = "meajudaai-provider-silver";
 
     /// <summary>
-    /// Prestador de serviços no plano Gold (pago via Stripe).
+    /// Prestador de serviços no plano Gold.
     /// </summary>
     public const string ProviderGold = "meajudaai-provider-gold";
 
     /// <summary>
-    /// Prestador de serviços no plano Platinum (pago via Stripe).
+    /// Prestador de serviços no plano Platinum.
     /// </summary>
     public const string ProviderPlatinum = "meajudaai-provider-platinum";
 
     /// <summary>
-    /// Obtém todos os papéis disponíveis no sistema
+    /// Obtém todos os papéis disponíveis no sistema (Catálogo Canônico).
     /// </summary>
     public static readonly string[] AllRoles =
     [
+        AdminLegacy,
+        SystemAdmin,
         SuperAdmin,
-        Admin,
-        ProviderManager,
-        DocumentReviewer,
-        CatalogManager,
-        Operator,
-        ReportViewer,
-        Customer,
+        UserAdmin,
+        UserOperator,
+        User,
+        ProviderAdmin,
         Provider,
+        OrderAdmin,
+        OrderOperator,
+        ReportAdmin,
+        ReportViewer,
+        CatalogManager,
+        LocationManager,
+        Customer,
         ProviderStandard,
         ProviderSilver,
         ProviderGold,
-        ProviderPlatinum
+        ProviderPlatinum,
+        RoleConstants.LegacySystemAdmin,
+        RoleConstants.LegacySuperAdmin
     ];
 
     /// <summary>
-    /// Obtém papéis que possuem privilégios administrativos (Admin Portal)
+    /// Obtém papéis que possuem privilégios administrativos (Acesso ao Admin Portal).
     /// </summary>
     public static readonly string[] AdminRoles =
     [
+        AdminLegacy,
+        SystemAdmin,
         SuperAdmin,
-        Admin,
-        ProviderManager,
-        DocumentReviewer,
+        UserAdmin,
+        ProviderAdmin,
+        OrderAdmin,
+        ReportAdmin,
         CatalogManager,
-        Operator,
-        ReportViewer
+        LocationManager,
+        RoleConstants.LegacySystemAdmin,
+        RoleConstants.LegacySuperAdmin
     ];
 
     /// <summary>
-    /// Obtém papéis disponíveis para aplicativo do cliente
-    /// </summary>
-    public static readonly string[] CustomerRoles =
-    [
-        Customer
-    ];
-
-    /// <summary>
-    /// Obtém todos os papéis de prestador (qualquer tier)
+    /// Obtém todos os papéis de prestador (qualquer tier).
     /// </summary>
     public static readonly string[] ProviderRoles =
     [
@@ -133,30 +164,24 @@ public static class UserRoles
     ];
 
     /// <summary>
-    /// Valida se um papel é válido no sistema
+    /// Valida se um papel é válido no sistema.
     /// </summary>
-    /// <param name="role">Papel a ser validado</param>
-    /// <returns>True se o papel for válido, false caso contrário</returns>
     public static bool IsValidRole(string role)
     {
         return AllRoles.Contains(role, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>
-    /// Valida se um papel possui privilégios administrativos
+    /// Valida se um papel possui privilégios administrativos.
     /// </summary>
-    /// <param name="role">Papel a ser verificado</param>
-    /// <returns>True se o papel for de nível admin, false caso contrário</returns>
     public static bool IsAdminRole(string role)
     {
         return AdminRoles.Contains(role, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>
-    /// Valida se um papel é de prestador de serviços (qualquer tier)
+    /// Valida se um papel é de prestador de serviços.
     /// </summary>
-    /// <param name="role">Papel a ser verificado</param>
-    /// <returns>True se o papel for de prestador, false caso contrário</returns>
     public static bool IsProviderRole(string role)
     {
         return ProviderRoles.Contains(role, StringComparer.OrdinalIgnoreCase);

--- a/tests/MeAjudaAi.ApiService.Tests/Unit/Handlers/SelfOrAdminHandlerTests.cs
+++ b/tests/MeAjudaAi.ApiService.Tests/Unit/Handlers/SelfOrAdminHandlerTests.cs
@@ -1,8 +1,10 @@
 using System.Security.Claims;
 using FluentAssertions;
 using MeAjudaAi.ApiService.Handlers;
+using MeAjudaAi.Shared.Utilities.Constants;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Xunit;
 
 namespace MeAjudaAi.ApiService.Tests.Unit.Handlers;
 
@@ -35,17 +37,24 @@ public class SelfOrAdminHandlerTests
         context.HasFailed.Should().BeTrue();
     }
 
-    [Fact]
-    public async Task HandleRequirementAsync_WithAdminRole_ShouldSucceed()
+    [Theory]
+    [InlineData(RoleConstants.Admin)]
+    [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.LegacySuperAdmin)]
+    public async Task HandleRequirementAsync_WithAdminRole_ShouldSucceed(string adminRole)
     {
         // Arrange
-        var claims = new[]
+        var claims = new List<Claim>
         {
-            new Claim("sub", "user123"),
-            new Claim("roles", "admin")
+            new Claim(AuthConstants.Claims.Subject, "user123"),
+            new Claim(AuthConstants.Claims.Roles, adminRole)
         };
+        
         var identity = new ClaimsIdentity(claims, "test");
         var user = new ClaimsPrincipal(identity);
+        
         var resource = new DefaultHttpContext();
         var context = new AuthorizationHandlerContext([_requirement], user, resource);
 
@@ -64,7 +73,7 @@ public class SelfOrAdminHandlerTests
         var userId = "user123";
         var claims = new[]
         {
-            new Claim("sub", userId)
+            new Claim(AuthConstants.Claims.Subject, userId)
         };
         var identity = new ClaimsIdentity(claims, "test");
         var user = new ClaimsPrincipal(identity);
@@ -88,7 +97,7 @@ public class SelfOrAdminHandlerTests
         // Arrange
         var claims = new[]
         {
-            new Claim("sub", "user123")
+            new Claim(AuthConstants.Claims.Subject, "user123")
         };
         var identity = new ClaimsIdentity(claims, "test");
         var user = new ClaimsPrincipal(identity);
@@ -133,7 +142,7 @@ public class SelfOrAdminHandlerTests
         // Arrange
         var claims = new[]
         {
-            new Claim("sub", "user123")
+            new Claim(AuthConstants.Claims.Subject, "user123")
         };
         var identity = new ClaimsIdentity(claims, "test");
         var user = new ClaimsPrincipal(identity);

--- a/tests/MeAjudaAi.ApiService.Tests/Unit/Handlers/SelfOrAdminHandlerTests.cs
+++ b/tests/MeAjudaAi.ApiService.Tests/Unit/Handlers/SelfOrAdminHandlerTests.cs
@@ -38,18 +38,21 @@ public class SelfOrAdminHandlerTests
     }
 
     [Theory]
-    [InlineData(RoleConstants.Admin)]
-    [InlineData(RoleConstants.SystemAdmin)]
-    [InlineData(RoleConstants.SuperAdmin)]
-    [InlineData(RoleConstants.LegacySystemAdmin)]
-    [InlineData(RoleConstants.LegacySuperAdmin)]
-    public async Task HandleRequirementAsync_WithAdminRole_ShouldSucceed(string adminRole)
+    [InlineData(RoleConstants.Admin, AuthConstants.Claims.Roles)]
+    [InlineData(RoleConstants.SystemAdmin, AuthConstants.Claims.Roles)]
+    [InlineData(RoleConstants.SuperAdmin, AuthConstants.Claims.Roles)]
+    [InlineData(RoleConstants.Admin, ClaimTypes.Role)]
+    [InlineData(RoleConstants.SystemAdmin, ClaimTypes.Role)]
+    [InlineData(RoleConstants.SuperAdmin, ClaimTypes.Role)]
+    [InlineData(RoleConstants.LegacySystemAdmin, AuthConstants.Claims.Roles)]
+    [InlineData(RoleConstants.LegacySuperAdmin, ClaimTypes.Role)]
+    public async Task HandleRequirementAsync_WithAdminRole_ShouldSucceed(string adminRole, string claimType)
     {
         // Arrange
         var claims = new List<Claim>
         {
             new Claim(AuthConstants.Claims.Subject, "user123"),
-            new Claim(AuthConstants.Claims.Roles, adminRole)
+            new Claim(claimType, adminRole)
         };
         
         var identity = new ClaimsIdentity(claims, "test");

--- a/tests/MeAjudaAi.Integration.Tests/Modules/Users/UserRepositoryIntegrationTests.cs
+++ b/tests/MeAjudaAi.Integration.Tests/Modules/Users/UserRepositoryIntegrationTests.cs
@@ -159,7 +159,10 @@ public class UserRepositoryIntegrationTests : BaseApiTest
     private User CreateValidUser()
     {
         var suffix = Guid.NewGuid().ToString("n")[..6];
-        var username = new Username(_faker.Internet.UserName() + "_" + suffix);
+        var fakerUser = _faker.Internet.UserName();
+        if (fakerUser.Length > 20) fakerUser = fakerUser[..20];
+        
+        var username = new Username(fakerUser + "_" + suffix);
         var email = new Email(suffix + "_" + _faker.Internet.Email());
         var firstName = _faker.Name.FirstName();
         var lastName = _faker.Name.LastName();

--- a/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
+++ b/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
@@ -22,8 +22,9 @@ public class UserRolesTests
             UserRoles.DocumentReviewer,
             UserRoles.CatalogManager,
             UserRoles.Operator,
-            UserRoles.Viewer,
+            UserRoles.ReportViewer,
             UserRoles.Customer,
+            UserRoles.Provider,
             UserRoles.ProviderStandard,
             UserRoles.ProviderSilver,
             UserRoles.ProviderGold,
@@ -43,7 +44,8 @@ public class UserRolesTests
             UserRoles.ProviderManager,
             UserRoles.DocumentReviewer,
             UserRoles.CatalogManager,
-            UserRoles.Operator
+            UserRoles.Operator,
+            UserRoles.ReportViewer
         });
     }
 
@@ -65,8 +67,9 @@ public class UserRolesTests
         UserRoles.DocumentReviewer.Should().Be(RoleConstants.LegacySystemAdmin);
         UserRoles.CatalogManager.Should().Be(RoleConstants.CatalogManager);
         UserRoles.Operator.Should().Be(RoleConstants.UserOperator);
-        UserRoles.Viewer.Should().Be("meajudaai-viewer");
+        UserRoles.ReportViewer.Should().Be(RoleConstants.ReportViewer);
         UserRoles.Customer.Should().Be("customer");
+        UserRoles.Provider.Should().Be(RoleConstants.Provider);
         UserRoles.ProviderStandard.Should().Be("meajudaai-provider-standard");
         UserRoles.ProviderSilver.Should().Be("meajudaai-provider-silver");
         UserRoles.ProviderGold.Should().Be("meajudaai-provider-gold");
@@ -84,8 +87,9 @@ public class UserRolesTests
     [InlineData(RoleConstants.LegacySystemAdmin)]
     [InlineData(RoleConstants.CatalogManager)]
     [InlineData(RoleConstants.UserOperator)]
-    [InlineData("meajudaai-viewer")]
+    [InlineData(RoleConstants.ReportViewer)]
     [InlineData("customer")]
+    [InlineData(RoleConstants.Provider)]
     [InlineData("meajudaai-provider-standard")]
     [InlineData("meajudaai-provider-silver")]
     [InlineData("meajudaai-provider-gold")]
@@ -155,6 +159,7 @@ public class UserRolesTests
     [InlineData(RoleConstants.LegacySystemAdmin)]
     [InlineData(RoleConstants.CatalogManager)]
     [InlineData(RoleConstants.UserOperator)]
+    [InlineData(RoleConstants.ReportViewer)]
     public void IsAdminRole_WithAdminRole_ShouldReturnTrue(string role)
     {
         // Act
@@ -168,6 +173,7 @@ public class UserRolesTests
     [InlineData("MEAJUDAAI-SYSTEM-ADMIN")]
     [InlineData("MeAjudaAi-PrOvIdEr-AdMiN")]
     [InlineData("SYSTEM-ADMIN")]
+    [InlineData("MEAJUDAAI-REPORT-VIEWER")]
     public void IsAdminRole_WithAdminRoleDifferentCase_ShouldReturnTrue(string role)
     {
         // Act
@@ -179,7 +185,6 @@ public class UserRolesTests
 
     [Theory]
     [InlineData("customer")]
-    [InlineData("meajudaai-viewer")]
     [InlineData("meajudaai-provider-standard")]
     [InlineData("meajudaai-provider-silver")]
     [InlineData("meajudaai-provider-gold")]
@@ -221,6 +226,7 @@ public class UserRolesTests
     #region IsProviderRole Tests
 
     [Theory]
+    [InlineData(RoleConstants.Provider)]
     [InlineData("meajudaai-provider-standard")]
     [InlineData("meajudaai-provider-silver")]
     [InlineData("meajudaai-provider-gold")]
@@ -241,8 +247,8 @@ public class UserRolesTests
     [InlineData(RoleConstants.LegacySystemAdmin)]
     [InlineData(RoleConstants.CatalogManager)]
     [InlineData(RoleConstants.UserOperator)]
+    [InlineData(RoleConstants.ReportViewer)]
     [InlineData("customer")]
-    [InlineData("meajudaai-viewer")]
     public void IsProviderRole_WithNonProviderRole_ShouldReturnFalse(string role)
     {
         // Act
@@ -276,6 +282,7 @@ public class UserRolesTests
     }
 
     [Theory]
+    [InlineData("MeAjudaAi-PrOvIdEr")]
     [InlineData("MeAjudaAi-PrOvIdEr-StAnDaRd")]
     [InlineData("MEAJUDAAI-PROVIDER-SILVER")]
     [InlineData("MeAjudaAi-PrOvIdEr-GoLd")]
@@ -320,6 +327,7 @@ public class UserRolesTests
         // Assert
         UserRoles.ProviderRoles.Should().BeEquivalentTo(new[]
         {
+            UserRoles.Provider,
             UserRoles.ProviderStandard,
             UserRoles.ProviderSilver,
             UserRoles.ProviderGold,

--- a/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
+++ b/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using MeAjudaAi.Shared.Utilities;
+using MeAjudaAi.Shared.Utilities.Constants;
 using Xunit;
 
 namespace MeAjudaAi.Shared.Tests.Unit.Utilities;
@@ -58,18 +59,18 @@ public class UserRolesTests
     public void RoleConstants_ShouldHaveExpectedValues()
     {
         // Assert
-        UserRoles.SuperAdmin.Should().Be("super-admin");
-        UserRoles.Admin.Should().Be("admin");
-        UserRoles.ProviderManager.Should().Be("provider-manager");
-        UserRoles.DocumentReviewer.Should().Be("document-reviewer");
-        UserRoles.CatalogManager.Should().Be("catalog-manager");
-        UserRoles.Operator.Should().Be("operator");
-        UserRoles.Viewer.Should().Be("viewer");
+        UserRoles.SuperAdmin.Should().Be(RoleConstants.SuperAdmin);
+        UserRoles.Admin.Should().Be(RoleConstants.SystemAdmin);
+        UserRoles.ProviderManager.Should().Be(RoleConstants.ProviderAdmin);
+        UserRoles.DocumentReviewer.Should().Be(RoleConstants.LegacySystemAdmin);
+        UserRoles.CatalogManager.Should().Be(RoleConstants.CatalogManager);
+        UserRoles.Operator.Should().Be(RoleConstants.UserOperator);
+        UserRoles.Viewer.Should().Be("meajudaai-viewer");
         UserRoles.Customer.Should().Be("customer");
-        UserRoles.ProviderStandard.Should().Be("provider-standard");
-        UserRoles.ProviderSilver.Should().Be("provider-silver");
-        UserRoles.ProviderGold.Should().Be("provider-gold");
-        UserRoles.ProviderPlatinum.Should().Be("provider-platinum");
+        UserRoles.ProviderStandard.Should().Be("meajudaai-provider-standard");
+        UserRoles.ProviderSilver.Should().Be("meajudaai-provider-silver");
+        UserRoles.ProviderGold.Should().Be("meajudaai-provider-gold");
+        UserRoles.ProviderPlatinum.Should().Be("meajudaai-provider-platinum");
     }
 
     #endregion
@@ -77,18 +78,18 @@ public class UserRolesTests
     #region IsValidRole Tests
 
     [Theory]
-    [InlineData("super-admin")]
-    [InlineData("admin")]
-    [InlineData("provider-manager")]
-    [InlineData("document-reviewer")]
-    [InlineData("catalog-manager")]
-    [InlineData("operator")]
-    [InlineData("viewer")]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.ProviderAdmin)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.CatalogManager)]
+    [InlineData(RoleConstants.UserOperator)]
+    [InlineData("meajudaai-viewer")]
     [InlineData("customer")]
-    [InlineData("provider-standard")]
-    [InlineData("provider-silver")]
-    [InlineData("provider-gold")]
-    [InlineData("provider-platinum")]
+    [InlineData("meajudaai-provider-standard")]
+    [InlineData("meajudaai-provider-silver")]
+    [InlineData("meajudaai-provider-gold")]
+    [InlineData("meajudaai-provider-platinum")]
     public void IsValidRole_WithValidRole_ShouldReturnTrue(string role)
     {
         // Act
@@ -99,15 +100,15 @@ public class UserRolesTests
     }
 
     [Theory]
-    [InlineData("Super-Admin")]
-    [InlineData("ADMIN")]
-    [InlineData("Provider-Manager")]
-    [InlineData("DOCUMENT-REVIEWER")]
-    [InlineData("Catalog-Manager")]
-    [InlineData("Provider-Standard")]
-    [InlineData("PROVIDER-SILVER")]
-    [InlineData("ProViDeR-GoLd")]
-    [InlineData("PrOvIdEr-PlAtInUm")]
+    [InlineData("MeAjudaAi-SuPeR-AdMiN")]
+    [InlineData("MEAJUDAAI-SYSTEM-ADMIN")]
+    [InlineData("MeAjudaAi-PrOvIdEr-AdMiN")]
+    [InlineData("SYSTEM-ADMIN")]
+    [InlineData("MeAjudaAi-CaTaLoG-MaNaGeR")]
+    [InlineData("MeAjudaAi-PrOvIdEr-StAnDaRd")]
+    [InlineData("MEAJUDAAI-PROVIDER-SILVER")]
+    [InlineData("MeAjudaAi-PrOvIdEr-GoLd")]
+    [InlineData("MeAjudaAi-PrOvIdEr-PlAtInUm")]
     public void IsValidRole_WithValidRoleDifferentCase_ShouldReturnTrue(string role)
     {
         // Act
@@ -148,12 +149,12 @@ public class UserRolesTests
     #region IsAdminRole Tests
 
     [Theory]
-    [InlineData("super-admin")]
-    [InlineData("admin")]
-    [InlineData("provider-manager")]
-    [InlineData("document-reviewer")]
-    [InlineData("catalog-manager")]
-    [InlineData("operator")]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.ProviderAdmin)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.CatalogManager)]
+    [InlineData(RoleConstants.UserOperator)]
     public void IsAdminRole_WithAdminRole_ShouldReturnTrue(string role)
     {
         // Act
@@ -164,9 +165,9 @@ public class UserRolesTests
     }
 
     [Theory]
-    [InlineData("ADMIN")]
-    [InlineData("Provider-Manager")]
-    [InlineData("DOCUMENT-REVIEWER")]
+    [InlineData("MEAJUDAAI-SYSTEM-ADMIN")]
+    [InlineData("MeAjudaAi-PrOvIdEr-AdMiN")]
+    [InlineData("SYSTEM-ADMIN")]
     public void IsAdminRole_WithAdminRoleDifferentCase_ShouldReturnTrue(string role)
     {
         // Act
@@ -178,11 +179,11 @@ public class UserRolesTests
 
     [Theory]
     [InlineData("customer")]
-    [InlineData("viewer")]
-    [InlineData("provider-standard")]
-    [InlineData("provider-silver")]
-    [InlineData("provider-gold")]
-    [InlineData("provider-platinum")]
+    [InlineData("meajudaai-viewer")]
+    [InlineData("meajudaai-provider-standard")]
+    [InlineData("meajudaai-provider-silver")]
+    [InlineData("meajudaai-provider-gold")]
+    [InlineData("meajudaai-provider-platinum")]
     public void IsAdminRole_WithNonAdminRole_ShouldReturnFalse(string role)
     {
         // Act
@@ -220,10 +221,10 @@ public class UserRolesTests
     #region IsProviderRole Tests
 
     [Theory]
-    [InlineData("provider-standard")]
-    [InlineData("provider-silver")]
-    [InlineData("provider-gold")]
-    [InlineData("provider-platinum")]
+    [InlineData("meajudaai-provider-standard")]
+    [InlineData("meajudaai-provider-silver")]
+    [InlineData("meajudaai-provider-gold")]
+    [InlineData("meajudaai-provider-platinum")]
     public void IsProviderRole_WithProviderRole_ShouldReturnTrue(string role)
     {
         // Act
@@ -234,14 +235,14 @@ public class UserRolesTests
     }
 
     [Theory]
-    [InlineData("super-admin")]
-    [InlineData("admin")]
-    [InlineData("provider-manager")]
-    [InlineData("document-reviewer")]
-    [InlineData("catalog-manager")]
-    [InlineData("operator")]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.ProviderAdmin)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.CatalogManager)]
+    [InlineData(RoleConstants.UserOperator)]
     [InlineData("customer")]
-    [InlineData("viewer")]
+    [InlineData("meajudaai-viewer")]
     public void IsProviderRole_WithNonProviderRole_ShouldReturnFalse(string role)
     {
         // Act
@@ -275,10 +276,10 @@ public class UserRolesTests
     }
 
     [Theory]
-    [InlineData("Provider-Standard")]
-    [InlineData("PROVIDER-SILVER")]
-    [InlineData("provider-GOLD")]
-    [InlineData("PrOvIdEr-PlAtInUm")]
+    [InlineData("MeAjudaAi-PrOvIdEr-StAnDaRd")]
+    [InlineData("MEAJUDAAI-PROVIDER-SILVER")]
+    [InlineData("MeAjudaAi-PrOvIdEr-GoLd")]
+    [InlineData("MeAjudaAi-PrOvIdEr-PlAtInUm")]
     public void IsProviderRole_WithValidRoleDifferentCase_ShouldReturnTrue(string role)
     {
         // Act

--- a/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
+++ b/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
@@ -13,7 +13,7 @@ public class UserRolesTests
     public void AllRoles_ShouldContainAllDefinedRoles()
     {
         // Assert
-        UserRoles.AllRoles.Should().HaveCount(12);
+        UserRoles.AllRoles.Should().HaveCount(13);
         UserRoles.AllRoles.Should().Contain(new[]
         {
             UserRoles.SuperAdmin,
@@ -36,7 +36,7 @@ public class UserRolesTests
     public void AdminRoles_ShouldContainOnlyAdminRoles()
     {
         // Assert
-        UserRoles.AdminRoles.Should().HaveCount(6);
+        UserRoles.AdminRoles.Should().HaveCount(7);
         UserRoles.AdminRoles.Should().Contain(new[]
         {
             UserRoles.SuperAdmin,

--- a/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
+++ b/tests/MeAjudaAi.Shared.Tests/Unit/Utilities/UserRolesTests.cs
@@ -13,22 +13,30 @@ public class UserRolesTests
     public void AllRoles_ShouldContainAllDefinedRoles()
     {
         // Assert
-        UserRoles.AllRoles.Should().HaveCount(13);
+        UserRoles.AllRoles.Should().HaveCount(21);
         UserRoles.AllRoles.Should().Contain(new[]
         {
+            UserRoles.AdminLegacy,
+            UserRoles.SystemAdmin,
             UserRoles.SuperAdmin,
-            UserRoles.Admin,
-            UserRoles.ProviderManager,
-            UserRoles.DocumentReviewer,
-            UserRoles.CatalogManager,
-            UserRoles.Operator,
-            UserRoles.ReportViewer,
-            UserRoles.Customer,
+            UserRoles.UserAdmin,
+            UserRoles.UserOperator,
+            UserRoles.User,
+            UserRoles.ProviderAdmin,
             UserRoles.Provider,
+            UserRoles.OrderAdmin,
+            UserRoles.OrderOperator,
+            UserRoles.ReportAdmin,
+            UserRoles.ReportViewer,
+            UserRoles.CatalogManager,
+            UserRoles.LocationManager,
+            UserRoles.Customer,
             UserRoles.ProviderStandard,
             UserRoles.ProviderSilver,
             UserRoles.ProviderGold,
-            UserRoles.ProviderPlatinum
+            UserRoles.ProviderPlatinum,
+            RoleConstants.LegacySystemAdmin,
+            RoleConstants.LegacySuperAdmin
         });
     }
 
@@ -36,40 +44,42 @@ public class UserRolesTests
     public void AdminRoles_ShouldContainOnlyAdminRoles()
     {
         // Assert
-        UserRoles.AdminRoles.Should().HaveCount(7);
+        UserRoles.AdminRoles.Should().HaveCount(11);
         UserRoles.AdminRoles.Should().Contain(new[]
         {
+            UserRoles.AdminLegacy,
+            UserRoles.SystemAdmin,
             UserRoles.SuperAdmin,
-            UserRoles.Admin,
-            UserRoles.ProviderManager,
-            UserRoles.DocumentReviewer,
+            UserRoles.UserAdmin,
+            UserRoles.ProviderAdmin,
+            UserRoles.OrderAdmin,
+            UserRoles.ReportAdmin,
             UserRoles.CatalogManager,
-            UserRoles.Operator,
-            UserRoles.ReportViewer
+            UserRoles.LocationManager,
+            RoleConstants.LegacySystemAdmin,
+            RoleConstants.LegacySuperAdmin
         });
-    }
-
-    [Fact]
-    public void CustomerRoles_ShouldContainCustomerRole()
-    {
-        // Assert
-        UserRoles.CustomerRoles.Should().HaveCount(1);
-        UserRoles.CustomerRoles.Should().Contain(UserRoles.Customer);
     }
 
     [Fact]
     public void RoleConstants_ShouldHaveExpectedValues()
     {
         // Assert
+        UserRoles.AdminLegacy.Should().Be(RoleConstants.Admin);
+        UserRoles.SystemAdmin.Should().Be(RoleConstants.SystemAdmin);
         UserRoles.SuperAdmin.Should().Be(RoleConstants.SuperAdmin);
-        UserRoles.Admin.Should().Be(RoleConstants.SystemAdmin);
-        UserRoles.ProviderManager.Should().Be(RoleConstants.ProviderAdmin);
-        UserRoles.DocumentReviewer.Should().Be(RoleConstants.LegacySystemAdmin);
-        UserRoles.CatalogManager.Should().Be(RoleConstants.CatalogManager);
-        UserRoles.Operator.Should().Be(RoleConstants.UserOperator);
-        UserRoles.ReportViewer.Should().Be(RoleConstants.ReportViewer);
-        UserRoles.Customer.Should().Be("customer");
+        UserRoles.UserAdmin.Should().Be(RoleConstants.UserAdmin);
+        UserRoles.UserOperator.Should().Be(RoleConstants.UserOperator);
+        UserRoles.User.Should().Be(RoleConstants.User);
+        UserRoles.ProviderAdmin.Should().Be(RoleConstants.ProviderAdmin);
         UserRoles.Provider.Should().Be(RoleConstants.Provider);
+        UserRoles.OrderAdmin.Should().Be(RoleConstants.OrderAdmin);
+        UserRoles.OrderOperator.Should().Be(RoleConstants.OrderOperator);
+        UserRoles.ReportAdmin.Should().Be(RoleConstants.ReportAdmin);
+        UserRoles.ReportViewer.Should().Be(RoleConstants.ReportViewer);
+        UserRoles.CatalogManager.Should().Be(RoleConstants.CatalogManager);
+        UserRoles.LocationManager.Should().Be(RoleConstants.LocationManager);
+        UserRoles.Customer.Should().Be("customer");
         UserRoles.ProviderStandard.Should().Be("meajudaai-provider-standard");
         UserRoles.ProviderSilver.Should().Be("meajudaai-provider-silver");
         UserRoles.ProviderGold.Should().Be("meajudaai-provider-gold");
@@ -81,19 +91,27 @@ public class UserRolesTests
     #region IsValidRole Tests
 
     [Theory]
-    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.Admin)]
     [InlineData(RoleConstants.SystemAdmin)]
-    [InlineData(RoleConstants.ProviderAdmin)]
-    [InlineData(RoleConstants.LegacySystemAdmin)]
-    [InlineData(RoleConstants.CatalogManager)]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.UserAdmin)]
     [InlineData(RoleConstants.UserOperator)]
-    [InlineData(RoleConstants.ReportViewer)]
-    [InlineData("customer")]
+    [InlineData(RoleConstants.User)]
+    [InlineData(RoleConstants.ProviderAdmin)]
     [InlineData(RoleConstants.Provider)]
+    [InlineData(RoleConstants.OrderAdmin)]
+    [InlineData(RoleConstants.OrderOperator)]
+    [InlineData(RoleConstants.ReportAdmin)]
+    [InlineData(RoleConstants.ReportViewer)]
+    [InlineData(RoleConstants.CatalogManager)]
+    [InlineData(RoleConstants.LocationManager)]
+    [InlineData("customer")]
     [InlineData("meajudaai-provider-standard")]
     [InlineData("meajudaai-provider-silver")]
     [InlineData("meajudaai-provider-gold")]
     [InlineData("meajudaai-provider-platinum")]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.LegacySuperAdmin)]
     public void IsValidRole_WithValidRole_ShouldReturnTrue(string role)
     {
         // Act
@@ -106,13 +124,9 @@ public class UserRolesTests
     [Theory]
     [InlineData("MeAjudaAi-SuPeR-AdMiN")]
     [InlineData("MEAJUDAAI-SYSTEM-ADMIN")]
-    [InlineData("MeAjudaAi-PrOvIdEr-AdMiN")]
     [InlineData("SYSTEM-ADMIN")]
-    [InlineData("MeAjudaAi-CaTaLoG-MaNaGeR")]
-    [InlineData("MeAjudaAi-PrOvIdEr-StAnDaRd")]
-    [InlineData("MEAJUDAAI-PROVIDER-SILVER")]
+    [InlineData("MEAJUDAAI-REPORT-VIEWER")]
     [InlineData("MeAjudaAi-PrOvIdEr-GoLd")]
-    [InlineData("MeAjudaAi-PrOvIdEr-PlAtInUm")]
     public void IsValidRole_WithValidRoleDifferentCase_ShouldReturnTrue(string role)
     {
         // Act
@@ -127,8 +141,6 @@ public class UserRolesTests
     [InlineData("guest")]
     [InlineData("")]
     [InlineData(" ")]
-    [InlineData("user123")]
-    [InlineData("admin-user")]
     public void IsValidRole_WithInvalidRole_ShouldReturnFalse(string role)
     {
         // Act
@@ -153,13 +165,17 @@ public class UserRolesTests
     #region IsAdminRole Tests
 
     [Theory]
-    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.Admin)]
     [InlineData(RoleConstants.SystemAdmin)]
+    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.UserAdmin)]
     [InlineData(RoleConstants.ProviderAdmin)]
-    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.OrderAdmin)]
+    [InlineData(RoleConstants.ReportAdmin)]
     [InlineData(RoleConstants.CatalogManager)]
-    [InlineData(RoleConstants.UserOperator)]
-    [InlineData(RoleConstants.ReportViewer)]
+    [InlineData(RoleConstants.LocationManager)]
+    [InlineData(RoleConstants.LegacySystemAdmin)]
+    [InlineData(RoleConstants.LegacySuperAdmin)]
     public void IsAdminRole_WithAdminRole_ShouldReturnTrue(string role)
     {
         // Act
@@ -170,52 +186,16 @@ public class UserRolesTests
     }
 
     [Theory]
-    [InlineData("MEAJUDAAI-SYSTEM-ADMIN")]
-    [InlineData("MeAjudaAi-PrOvIdEr-AdMiN")]
-    [InlineData("SYSTEM-ADMIN")]
-    [InlineData("MEAJUDAAI-REPORT-VIEWER")]
-    public void IsAdminRole_WithAdminRoleDifferentCase_ShouldReturnTrue(string role)
-    {
-        // Act
-        var result = UserRoles.IsAdminRole(role);
-
-        // Assert
-        result.Should().BeTrue();
-    }
-
-    [Theory]
     [InlineData("customer")]
-    [InlineData("meajudaai-provider-standard")]
-    [InlineData("meajudaai-provider-silver")]
-    [InlineData("meajudaai-provider-gold")]
-    [InlineData("meajudaai-provider-platinum")]
+    [InlineData(RoleConstants.User)]
+    [InlineData(RoleConstants.Provider)]
+    [InlineData(RoleConstants.ReportViewer)]
+    [InlineData(RoleConstants.OrderOperator)]
+    [InlineData(RoleConstants.UserOperator)]
     public void IsAdminRole_WithNonAdminRole_ShouldReturnFalse(string role)
     {
         // Act
         var result = UserRoles.IsAdminRole(role);
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Theory]
-    [InlineData("invalid")]
-    [InlineData("")]
-    [InlineData(" ")]
-    public void IsAdminRole_WithInvalidRole_ShouldReturnFalse(string role)
-    {
-        // Act
-        var result = UserRoles.IsAdminRole(role);
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Fact]
-    public void IsAdminRole_WithNull_ShouldReturnFalse()
-    {
-        // Act
-        var result = UserRoles.IsAdminRole(null!);
 
         // Assert
         result.Should().BeFalse();
@@ -241,13 +221,8 @@ public class UserRolesTests
     }
 
     [Theory]
-    [InlineData(RoleConstants.SuperAdmin)]
+    [InlineData(RoleConstants.Admin)]
     [InlineData(RoleConstants.SystemAdmin)]
-    [InlineData(RoleConstants.ProviderAdmin)]
-    [InlineData(RoleConstants.LegacySystemAdmin)]
-    [InlineData(RoleConstants.CatalogManager)]
-    [InlineData(RoleConstants.UserOperator)]
-    [InlineData(RoleConstants.ReportViewer)]
     [InlineData("customer")]
     public void IsProviderRole_WithNonProviderRole_ShouldReturnFalse(string role)
     {
@@ -256,44 +231,6 @@ public class UserRolesTests
 
         // Assert
         result.Should().BeFalse();
-    }
-
-    [Theory]
-    [InlineData("invalid")]
-    [InlineData("")]
-    [InlineData(" ")]
-    public void IsProviderRole_WithInvalidRole_ShouldReturnFalse(string role)
-    {
-        // Act
-        var result = UserRoles.IsProviderRole(role);
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Fact]
-    public void IsProviderRole_WithNull_ShouldReturnFalse()
-    {
-        // Act
-        var result = UserRoles.IsProviderRole(null!);
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Theory]
-    [InlineData("MeAjudaAi-PrOvIdEr")]
-    [InlineData("MeAjudaAi-PrOvIdEr-StAnDaRd")]
-    [InlineData("MEAJUDAAI-PROVIDER-SILVER")]
-    [InlineData("MeAjudaAi-PrOvIdEr-GoLd")]
-    [InlineData("MeAjudaAi-PrOvIdEr-PlAtInUm")]
-    public void IsProviderRole_WithValidRoleDifferentCase_ShouldReturnTrue(string role)
-    {
-        // Act
-        var result = UserRoles.IsProviderRole(role);
-
-        // Assert
-        result.Should().BeTrue();
     }
 
     #endregion
@@ -308,13 +245,6 @@ public class UserRolesTests
     }
 
     [Fact]
-    public void CustomerRoles_ShouldBeSubsetOfAllRoles()
-    {
-        // Assert
-        UserRoles.CustomerRoles.Should().BeSubsetOf(UserRoles.AllRoles);
-    }
-
-    [Fact]
     public void ProviderRoles_ShouldBeSubsetOfAllRoles()
     {
         // Assert
@@ -322,10 +252,10 @@ public class UserRolesTests
     }
 
     [Fact]
-    public void ProviderRoles_ShouldContainOnlyProviderRoles()
+    public void ProviderRoles_ShouldContainExpectedTiers()
     {
         // Assert
-        UserRoles.ProviderRoles.Should().BeEquivalentTo(new[]
+        UserRoles.ProviderRoles.Should().Contain(new[]
         {
             UserRoles.Provider,
             UserRoles.ProviderStandard,


### PR DESCRIPTION
## Changes\n- Aligned Production realm with Development granular roles, clients, and identity providers.\n- Resolved Issue #141 by synchronizing Instagram login configuration.\n- Transferred Sprint 10 to history and promoted Sprint 11 as the current one.\n- Updated technical debt status for #141.\n\nFixes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentação**
  * Sprint 10 marcada como concluída com objetivo e entregáveis (Ratings, moderação, documentação) e roadmap atualizado para Sprint 11 em andamento.

* **Novas Funcionalidades**
  * Login social reintegrado (Google, Facebook, Instagram via OIDC).
  * Autorização ampliada com conjunto de papéis equivalente e novo papel SuperAdmin (compatibilidade com papéis legados).

* **Infraestrutura**
  * Atualizações em realms e clientes OIDC, ajustes de logout/claims e conta de serviço para tokens.

* **Tests**
  * Testes de autorização parametrizados e atualizados para usar constantes de papéis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->